### PR TITLE
Do not use safe and unsafe to describe pointer types.

### DIFF
--- a/spec/bounds_safety/checkedc.tex
+++ b/spec/bounds_safety/checkedc.tex
@@ -86,9 +86,9 @@
 \newcommand{\ptrint}{\ptrinst{\texttt{int}}}
 \newcommand{\ptrvoid}{\ptrinst{\texttt{void}}}
 
-\newcommand{\unsafeptrinst}[1]{\texttt{#1 *}}
-\newcommand{\unsafeptrT}{\texttt{\var{T} *}}
-\newcommand{\unsafeptrvoid}{\unsafeptrinst{void}}
+\newcommand{\uncheckedptrinst}[1]{\texttt{#1 *}}
+\newcommand{\uncheckedptrT}{\texttt{\var{T} *}}
+\newcommand{\uncheckedptrvoid}{\uncheckedptrinst{void}}
 
 %
 % bounds expression macros
@@ -122,7 +122,7 @@
 {\center
 \mbox{ }\\
 \vspace{2in}
-{\huge Extending C with pointer safety \par}
+{\huge Extending C with bounds safety \par}
 %{Version 0.4 (March 6, 2016) \par}
 {Version 0.5 - Draft as of \today \par}
 \vspace{0.5in}
@@ -183,6 +183,6 @@ This license is available at {\color{blue} \url{http://www.openwebfoundation.org
 
 \appendix
 % \include{fragments}
-% \include{array-view-compilation}
+% \include{span-compilation}
 
 \end{document}

--- a/spec/bounds_safety/checking-variable-bounds.tex
+++ b/spec/bounds_safety/checking-variable-bounds.tex
@@ -354,7 +354,7 @@ then \boundsinfer{\var{e4 op e1}}
                             {\texttt{GCD(\var{c}, sizeof(\var{T}))}}}.
 \end{quote}
 
-\subsubsection{Unsafe pointer arithmetic}
+\subsubsection{Pointer arithmetic for unchecked pointer types}
 
 Pointer arithmetic involving an \arrayptr\ value checks that
 the value is non-null and generates a runtime error if it is. This check
@@ -365,10 +365,10 @@ prevents a null pointer that has invalid bounds from being used to create a
 non-null pointer with valid bounds, which could then be used to access
 memory.
 
-Because the meaning of unsafe pointers has not changed, pointer
-arithmetic involving a null unsafe pointer may not generate a runtime
+Because the meaning of unchecked pointers has not changed, pointer
+arithmetic involving a null unchecked pointer may not generate a runtime
 error. The rules for array\_ptr pointer arithmetic can be applied to
-unsafe pointer arithmetic, however, provided that a side condition that
+unchecked pointer arithmetic, however, provided that a side condition that
 the pointer expression is non-null is added:
 
 \begin{quote}
@@ -645,7 +645,7 @@ while (p < high) {
 }
 \end{verbatim}
 
-Bounds safety is preserved when the range of a bounds expression is
+Bounds ty is preserved when the range of a bounds expression is
 narrowed. \texttt{(p - 1, high)} implies that \texttt{(p, high)} is a
 valid bounds expression. This reestablishes the loop bounds invariant
 for \texttt{p} of \texttt{(p, high)}.
@@ -657,8 +657,8 @@ while (p < high) {
 }
 \end{verbatim}
 
-The correctness of narrowing depends on safe pointer arithmetic overflow
-being a runtime error. For a lower bound \var{e1} in a bounds
+The correctness of narrowing depends on pointer arithmetic overflow
+for checked pointer types being a runtime error. For a lower bound \var{e1} in a bounds
 expression, we can only substitute \var{e2} for \var{e1} as the lower
 bound if \var{e2} \textgreater{}= \var{e1}. The identity \texttt{p > p - 1} 
 holds only if overflow is a runtime error.
@@ -687,7 +687,7 @@ An expression is invertible with respect to a variable x if:
   \end{enumerate}
 \end{enumerate}
 
-The addition and subtraction operations must be for safe pointer
+The addition and subtraction operations must be for checked pointer
 arithmetic or unsigned integer arithmetic. An implementation may allow
 integral addition and subtraction operations to be invertible if
 integral addition and subtraction are defined as two's complement
@@ -1123,7 +1123,7 @@ array_ptr<void> malloc(size_t num) : byte_count(num);
 \end{verbatim}
 
 even though in practice it will have a bounds-safe interface that does
-not use a safe pointer type.
+not use a checked pointer type.
 
 First, the implicit casts are made explicit and count is expanded to bounds:
 

--- a/spec/bounds_safety/core-extensions.tex
+++ b/spec/bounds_safety/core-extensions.tex
@@ -14,7 +14,7 @@ Finally, it describes changes to
 undefined behavior needed for bounds safety.
 
 \section{New kinds of pointer types}
-Three new safe pointer types are added to C. Each pointer type can be
+Three new checked pointer types are added to C. Each pointer type can be
 used in place of `*'
 
 \begin{enumerate}
@@ -45,8 +45,8 @@ used in place of `*'
   \arrayptrT .
 \end{enumerate}
 
-Unsafe C pointer types that use \texttt{*} and are unchecked in their
-ranges continue to exist. Pointer arithmetic is not forbidden on unsafe
+Unchecked C pointer types that use \texttt{*} and are unchecked in their
+ranges continue to exist. Pointer arithmetic is not forbidden on unchecked
 pointer types because it would break existing C code. C compilers will
 have an error or warning mode that flags unexpected uses of `*'.
 
@@ -63,8 +63,8 @@ support decrementing the \spanptr.
 
 \section{New kinds of array types}
 
-A new safe array type is added to C. Just as there are safe pointer
-types, there are safe array types. They are declared by placing the
+A new checked array type is added to C. Just as there are checked pointer
+types, there are checked array types. They are declared by placing the
 modifier \keyword{checked} before the declaration of the bound of the
 array\footnote{We can just as easily adopt the syntax that the checked
 annotation is postfix and propagates from the inner most array to the
@@ -190,13 +190,13 @@ The following operations involving pointer-typed values are allowed:
   Pointers to objects of the same type can be compared for equality or
   inequality. The pointers do not have to be the same kind of pointer.
   To support reasoning about program behavior, the result of comparing
-  pointers to different objects must be defined.  Safe pointers can also
+  pointers to different objects must be defined.  Checked pointers can also
   be compared for equality or inequality with 0 and void pointers, 
-  just like unsafe pointers.
+  just like unchecked pointers.
 \item
   Pointers to objects of the same type can be compared relationally. Relational comparisons are the
   \verb|<|, \verb|<=|, \verb|>|, \verb|>=| operators. The pointers do not have to be
-  the same kind of pointer. For example, an \unsafeptrT\ can be compared with an
+  the same kind of pointer. For example, an \uncheckedptrT\ can be compared with an
   \arrayptrT . To support bounds checking and reasoning about program behavior, the
   result of comparing pointers to different objects must be defined.
   Section~\ref{section:changes-to-undefined-behavior} describes this requirement in detail.
@@ -209,7 +209,7 @@ The following operations involving pointer-typed values are allowed:
 \end{itemize}
 
 A value of one pointer type may be converted to a value of another
-pointer type. For casts to or from safe pointer types where
+pointer type. For casts to or from checked pointer types where
 bounds-safety can be checked at compile-time, a cast operator can be
 used. If bounds safety cannot be checked at compile-time, bounds cast
 operators must be used. There are two kinds of bounds cast operators:
@@ -268,14 +268,14 @@ variables from being modifiable.
 
 \subsection{Variable and member initialization}
 
-Variables and member of variables with new safe pointer types must be initialized
+Variables and members of variables with checked pointer types must be initialized
 before they are used.  For \arrayptr s, this is checked as part of checking
 the validity of bounds.  For \ptr s and \spanptr s, this is checked
 using a separate analysis.   A use includes taking the address of a variable
 or member of a variable.  It is often unclear when the resulting pointer is used,
 so the variable must be initialized when its address is taken.
 
-\subsection{\texttt{Span}\textit{T}\texttt{>} specific operations}
+\subsection{\texttt{Span<}\textit{T}\texttt{>} specific operations}
 
 A \spanptrT\
 pointer carries three values with it: the memory location that will be
@@ -339,7 +339,7 @@ in Section~\ref{section:pointer-casting}.
 \section{Pointer arithmetic error conditions}
 \label{section:pointer-arithmetic-errors}
 
-For existing unsafe C pointers, the definition of pointer arithmetic is
+For existing unchecked C pointers, the definition of pointer arithmetic is
 described in terms of addresses of elements of an array object. The C
 Standard \cite{ISO2011} states, that given a pointer p that points to some element i of
 an array object, p + j points to the (i+j)th element of that object.
@@ -571,7 +571,7 @@ processors to never fail.
 \section{Relative alignment of \arrayptr\ and \spanptr\ values}
 \label{section:relative-alignment}
 
-\arrayptrT\ and \spanptrT\ pointers provide safe
+\arrayptrT\ and \spanptrT\ pointers provide
 pointer arithmetic on arrays. The bounds for these pointers usually
 describe a range of memory that is exactly the size of some array of \var{T}.
 The pointers point to an element of the array. In other words, the lower
@@ -599,25 +599,25 @@ increase the cost of bounds checking throughout the program.
 Section~\ref{section:design-alternatives:always-unaligned} explains
 this choice in more detail.
 
-\section{Program scopes for safe pointer types}
+\section{Program scopes for checked pointer types}
 
 To improve program reliability and to simplify understanding programs,
-it is desirable to limit code to using only safe pointers. To support
+it is desirable to limit code to using only checked pointers. To support
 this, we introduce checked program scopes. The \keyword{checked} keyword
 can be attached to blocks and function definitions. In checked program
 scopes, the declared types of variables are allowed to be or use
-safe pointer types or checked array types; unsafe pointer types
-and unsafe array types are not allowed.  Similarly, for functions,
-return types and parameter types are allowed to be or use safe pointer
+checked pointer types or checked array types; unchecked pointer types
+and unchecked array types are not allowed.  Similarly, for functions,
+return types and parameter types are allowed to be or use checked pointer
 types or checked array types.  
 
-On the other hand,  declarations in checked scopes can use unsafe pointer 
-types and unsafe array types, provided that the declarations provide a 
+On the other hand,  declarations in checked scopes can use unchecked pointer
+types and unchecked array types, provided that the declarations provide a
 bounds-safe interface.   These are described in
 Section~\ref{section:function-bounds-safe-interfaces}.
 Variables and functions used in checked scopes are 
-allowed to have or be safe pointer types, checked array types, or unsafe pointer types
-and unsafe array types with bounds declarations. 
+allowed to have or use checked pointer types, checked array types, or
+unchecked pointer types and unchecked array types with bounds declarations.
 
 A new pragma directive \texttt{BOUNDS\_CHECKED} is introduced to control whether
 the top-level scope is a checked scope:
@@ -650,7 +650,7 @@ checked
 \end{verbatim}
 
 It is rarer for a programmer to need to introduce an unchecked scope. It
-is usually needed to allow the use of unsafe pointers within a checked
+is needed usually to allow the use of unchecked pointers within a checked
 block. The \keyword{unchecked} keyword can be used in all the places where the
 checked keyword can be used. This example shows the use of an unchecked
 block:
@@ -680,7 +680,7 @@ checked  block. A checked function definition is declared by placing the
 unchecked function definitions:
 
 \begin{verbatim}
-// checked at the function level: no unsafe pointers can appear in argument
+// checked at the function level: no unchecked pointers can appear in argument
 // types, the return type, or the body of the function.
 checked int f(ptr<int> p) 
 {
@@ -689,8 +689,8 @@ checked int f(ptr<int> p)
     ...
 }
 
-// unchecked at the function level: Safe and unsafe pointer types can occur 
-// in argument types, the return type, or the body of the function
+// unchecked at the function level: checked and unchecked pointer types can 
+// occur in argument types, the return type, or the body of the function
 unchecked int f(int *p, ptr<int> r)
 {
     int a = 5;
@@ -743,9 +743,9 @@ for these reasons:
   checking cannot prove the fact, the programmer can use
   \texttt{dynamic\_check} to show that the condition is true.
 \item
-  It maintains programmer control: programmers can use unsafe ponters
+  It maintains programmer control: programmers can use unchecked pointers
   and \texttt{dynamic\_check} to write the same code that the compiler
-  would generate for safe pointers.
+  would generate for checked pointers.
 \item
   It gives programmers more control over bounds checks. A programmer can
   place a pre-condition before a loop that ensures that the loop is free
@@ -755,7 +755,7 @@ for these reasons:
 
 The following example illustrates why having an escape hatch from static
 checking is useful. Suppose a decoder from a compressed representation
-to an uncompressed representation is being converted to use safe
+to an uncompressed representation is being converted to use checked
 pointers. This example is based on code patterns seen in the Abstract
 Syntax Notation (ASN1) parsing code of OpenSSL \cite{OpenSSL2015}.
 
@@ -792,10 +792,10 @@ invariants cannot be expressed using lightweight invariants. These are
 complicated high-level invariants that require the use of techniques for
 proving functional correctness.
 
-To use safe pointers, the size of the destination buffer must be passed
+To use checked pointers, the size of the destination buffer must be passed
 in and there must be a check before the memcpy that the destination
 buffer and source buffer have enough room. We ignore the details of how
-the bounds are described for now.    The new code for safe pointers is italicized
+the bounds are described for now.    The new code for checked pointers is italicized
 and highlighted in yellow:
 
 \begin{alltt}
@@ -1021,15 +1021,15 @@ meaning of an expression is undefined:
 
 \begin{itemize}
 \item
-  Unsafe pointer arithmetic only has defined behavior when the resulting
-  pointer points to the same object as the original pointer, or one
+  Pointer arithmetic for unchecked pointer types only has defined behavior when
+  the resulting pointer points to the same object as the original pointer, or one
   element past the object.
 \item
-  Unsafe pointer comparison only has defined behavior when comparing
+  Pointer comparison for unchecked pointer types only has defined behavior when comparing
   pointers to the same object (where one or both pointers may point one
   element past the same object).
 \item
-  Unsafe pointer subtraction only has defined behavior when subtracting
+  Pointer subtraction for unchecked pointer types only has defined behavior when subtracting
   pointers to the same object (where one or both pointers may point one
   element past the object).
 \item
@@ -1081,19 +1081,19 @@ implementation-defined behavior, one has to reason about the
 implementation-specific behavior or have reasoning that is independent
 of the details.
 
-A careful reading of the rules for unsafe pointer comparison implies
-that it is impossible to detect an out-of-bounds unsafe pointer in C,
-for example. If an unsafe pointer \var{p} is not in the valid range for an
+A careful reading of the rules for unchecked pointer comparison implies
+that it is impossible to detect an out-of-bounds unchecked pointer in C,
+for example. If an unchecked pointer \var{p} is not in the valid range for an
 object, the pointer comparison is undefined.
 
 To provide for pointer bounds safety, we require that C implementations
-provide defined behaviors for unsafe pointer arithmetic operations and
+provide defined behaviors for unchecked pointer arithmetic operations and
 signed integer overflow:
 
 \begin{itemize}
 \item
-  Unsafe pointers shall be treated as addresses of locations in memory,
-  just as safe pointers are treated as addressses. The addresses shall
+  Unchecked pointers shall be treated as addresses of locations in memory,
+  just as checked pointers are treated as addressses. The addresses shall
   be unsigned integers with a defined range of 0 to
   \texttt{UINTPTR\_MAX}:
 
@@ -1104,9 +1104,9 @@ signed integer overflow:
   \item
     Subtraction \var{p} \texttt{-} \var{r} of two pointers \var{p} and \var{r}
     of type \var{T} where one
-    pointer is a safe pointer and the other is an unsafe pointer shall
-    be done following the rules for subtraction of safe pointers,
-    treating the unsafe pointer as a safe pointer in those rules.
+    pointer is a checked pointer and the other is an unchecked pointer shall
+    be done following the rules for subtraction of checked pointers,
+    treating the unchecked pointer as a checked pointer in those rules.
   \end{itemize}
 \end{itemize}
 
@@ -1157,9 +1157,9 @@ The aim is to be able to show partial correctness of programs for the
 first item (avoiding out-of-bounds pointer accesses). A
 partial correctness guarantee has the form ``assuming X holds, then Y is
 true''. Informally, one might say ``assuming that memory allocation and
-type casts are correct and that unsafe code never reads or write though
-out-of-bounds pointers, then safe code never reads or writes through
+type casts are correct and that unchecked code never reads or write though
+out-of-bounds pointers, then checked code never reads or writes through
 out-of-bounds pointers.'' These assumptions can be turned into formal
 statements about program behavior at runtime. Given those assumptions,
-we might then prove that at runtime safe code never reads or writes
+we might then prove that at runtime checked code never reads or writes
 through out-of-bounds pointers.

--- a/spec/bounds_safety/design-alternatives.tex
+++ b/spec/bounds_safety/design-alternatives.tex
@@ -80,12 +80,12 @@ and bounds are relatively aligned in order to eliminate the upper bounds
 check. It would be hard for a compiler to prove this because it would
 require interprocedural or whole-program analysis.
 
-\section{Address-of operations and array-to-pointer conversions always produce safe pointer types}
+\section{Address-of operations and array-to-pointer conversions always produce checked pointer types}
 
 We considered a design where the address-of operator (\&) and
-array-to-pointer type conversions always produce safe pointer types. To
+array-to-pointer type conversions always produce checked pointer types. To
 preserve compatibility with existing C code, we would introduce implicit
-conversions from safe pointers to unsafe pointers. We found that we were
+conversions from checked pointers to unchecked pointers. We found that we were
 not able to preserve backwards compatibility for the address-of operator
 and that implicit array-to-pointer conversions required bounds checking.
 
@@ -104,11 +104,11 @@ that add or subtract a pointer and an integer. Those situations include
 pointer assignment, arguments to function calls, return statements, and
 conditional expressions. In all these situations a \var{T} \texttt{*}
 type must have been declared explicitly in the code already, so this
-implicit cast does not introduce unsafe pointer types where none existed
+implicit cast does not introduce unchecked pointer types where none existed
 before.
 
 Pointer arithmetic operators are excluded to avoid the silent
-introduction of unsafe pointer types and to preserve the value of having
+introduction of unchecked pointer types and to preserve the value of having
 the \ptrT\ type. If
 there were always an implicit cast from \ptrT\ to \var{T} \texttt{*},
 then any expression that uses pointer arithmetic could do pointer
@@ -206,11 +206,12 @@ type for those operations and a coercion to T * is not needed.
 
 We allow \arrayptr\ values to not be within bounds. Because of
 this, any implicit conversion of an \arrayptr\ value with a
-bounds to an unsafe pointer type must be bounds checked. Otherwise, it
-is easy to write ``safe'' code that creates undetected buffer overruns:
+bounds to an unchecked pointer type must be bounds checked. Otherwise, it
+is easy to write ``checked'' code that creates undetected buffer overruns:
 
 \begin{verbatim}
-// f looks safe, but does something bad that is undetected before calling unsafe code
+// f looks like it is correct, but does something bad that is
+// undetected before calling unchecked code
 f(array_ptr<int> p where p : bounds(p, p + 10))
 {
     // first argument implicitly converted to int *

--- a/spec/bounds_safety/fragments.tex
+++ b/spec/bounds_safety/fragments.tex
@@ -77,15 +77,15 @@ assume that some undefined behaviors do not occur in some parts of code.
 We would be able to prove given this assumption that other undefined
 behaviors do not occur in other parts of the program. For example, we
 might assume memory allocation and type casts are in fact correct. We
-might also assume that unsafe code never reads or writes through
-out-of-bounds pointers. We would then be able to provide that safe code
+might also assume that unchecked code never reads or writes through
+out-of-bounds pointers. We would then be able to provide that checked code
 is guaranteed to never read or write through out-of-bounds pointers.
 
 To arrive at more complete correctness guarantees about systems, we will
 use the approaches of narrowing the amount of code about which
 assumptions have to be made and narrowing the types of assumptions that
 have to be made (that type casts are correct and memory allocation is
-correct). For example, we will narrow the amount of unsafe code so that
+correct). For example, we will narrow the amount of unchecked code so that
 assumptions are needed about less and less code.
 
 \section{Discussion of facts involving members}

--- a/spec/bounds_safety/interoperation.tex
+++ b/spec/bounds_safety/interoperation.tex
@@ -8,17 +8,17 @@
 \chapter{Interoperation}
 \label{chapter:interoperation}
 
-Code that uses safe pointer types must be able to interoperate with
-code that uses unsafe pointer types.  This chapter describes support
+Code that uses checked pointer types must be able to interoperate with
+code that uses unchecked pointer types.  This chapter describes support
 for this.  Section~\ref{section:pointer-casting} starts with
 conversion operations: how different kinds of pointers can
 be converted to other kinds of pointers.  
 Section~\ref{section:function-bounds-safe-interfaces}
-describes how existing code that uses unsafe pointers can be modified
-to present a safe interface.  The key insight is that the
-the interface must be both safe and unsafe, depending on context.
-For existing code that uses unsafe pointers, the interface is descriptive,
-but correctness is not enforced by the language.  For code that uses safe
+describes how existing code that uses unchecked pointers can be modified
+to present a safe interface.  The key insight is that
+the interface must be both checked and unchecked, depending on context.
+For existing code that uses unchecked pointers, the interface is descriptive,
+but correctness is not enforced by the language.  For code that uses checked
 pointers, proper usage of the interface is checked and enforced.
 
 \section{Conversions between pointers to objects of different types}
@@ -34,20 +34,20 @@ bounds safety.
 
 Type safety is not addressed by this technical report. Of course, violating
 type safety can lead to violations of bounds safety. This can happen
-when there is a conversion between a safe pointer to an object of
-structure type that contains a bounds-checked member and a safe pointer
+when there is a conversion between a checked pointer to an object of
+structure type that contains a bounds-checked member and a pointer
 to an object of another type. A programmer can use the pointer to the
 other type to modify the bounds-checked member or its bounds in an
 inconsistent fashion. For now, it is the programmer's responsibility to
 update bounds-checked members and their bounds properly when using a
-safe pointer that results from such a conversion. Conversions between
-safe pointers to integral types, floating-point types, or structures that
+checked pointer that results from such a conversion. Conversions between
+checked pointers to integral types, floating-point types, or structures that
 contain only integral types or floating-point types cannot lead to
 violations of bounds safety by themselves.
 
 \subsection{Cast operators}
 This section describes casts to pointer types.
-A conversion of a value from one safe pointer type to a value of another safe
+A conversion of a value from one checked pointer type to a value of another checked
 pointer type is valid when the following rules hold:
 \begin{itemize}
 \item If the destination pointer is a \ptrT\ type, the range of 
@@ -58,11 +58,11 @@ the bounds for the destination pointer are equal to or within the range of
 the memory accessible through the source pointer.
 \end{itemize}
 
-Casts between safe pointer types should preserve bounds safety
+Casts between checked pointer types should preserve bounds safety
 by default.  The cases where it does not should be the unusual cases.
-For this reason, C cast operations to safe pointer types are 
-required to be provably safe for bounds at compile-time.   It
-is straightforward to check casts between safe pointers to constant-sized
+For this reason, C cast operations to checked pointer types are
+required to be provably correct with respect to bounds at compile-time.   It
+is straightforward to check casts between checked pointers to constant-sized
 objects.   The rules that are used to check bounds and lightweight
 invariants are used to check casts as well.   For cases where static
 checking cannot prove bounds safety of casts, we add two new operators. 
@@ -74,11 +74,11 @@ describes the operators.
 \toprule
 Operator & Description \\
 \texttt{(T *)} & The C cast operator.  Additional static checking rules
-ensure pointer casts to safe pointer types are safe with respect to bounds.\\
+ensure pointer casts to checked pointer types are correct with respect to bounds.\\
 \dynamicboundscast\ & Does dynamic checks to ensure bounds
 safety.  It produces a runtime error if the checks fail.\\
 \assumeboundscast\ & Declares new bounds for the value that are trusted without verification.  
-Because it is unsafe, it is not allowed in \keyword{checked} blocks.\\
+Because it is unchecked, it is not allowed in \keyword{checked} blocks.\\
 \bottomrule
 \end{tabular}
 \caption{Cast operators for pointer types}
@@ -93,23 +93,24 @@ specified using an optional second argument:
 \dynamicboundscastinst{\var{T}, \var{A}}{} or \assumeboundscastinst{\var{T, \var{A}}}{}.
 Of course, macro-like syntax could be used as well.
 
-For C cast operations from safe pointer types to unsafe pointer types,
-it is not possible to prove that they are safe at compile-time.   At the same
-time, it is desirable catch the programming error of converting an out-of-range
-safe pointer to an unsafe pointer and then trying to use the unsafe
+For C cast operations from checked pointer types to unchecked pointer types,
+it is not possible to prove that the uses of the resulting unchecked pointers
+are correct at compile-time.   At the same
+time, it is desirable to  catch the programming error of converting an out-of-range
+checked pointer to an unchecked pointer and then trying to use the unchecked
 pointer to access memory.  For this reason, we take the stance that if the
-destination pointer is a \unsafeptrT\ type, the range of memory that can be accessed
-beginning at the safe pointer should be provably large enough at compile time 
+destination pointer is a \uncheckedptrT\ type, the range of memory that can be accessed
+beginning at the checked pointer should be provably large enough at compile time
 to hold a value of type \var{T}.
 
-C does allow an unsafe pointer to point one element past the end of an array.
+C does allow an unchecked pointer to point one element past the end of an array.
 However, it is illegal to dereference that pointer.  This case mainly arises
 from loops that stride through an array and end up creating a pointer one past
 an element of an array.  It would be unusual for a programmer to
-convert a safe pointer to an unsafe pointer and then stride downwards through an array, 
-predecrementing the pointer.  Because of that, C cast operations from safe pointer
-types to unsafe pointer types that would create a pointer one element past
-the end of the array pointed to by the safe pointer are rejected at compile time.
+convert a checked pointer to an unchecked pointer and then stride downwards through an array,
+predecrementing the pointer.  Because of that, C cast operations from checked pointer
+types to unchecked pointer types that would create a pointer one element past
+the end of the array pointed to by the checked pointer are rejected at compile time.
 A programmer may use an \assumeboundscast\ operation do this instead.
 
 \subsection{Description of cast operators}
@@ -122,7 +123,7 @@ Here are the rules for cast operators of the form \texttt{(\var{D}) \var{e}},
 where \var{e} has source type \var{S}.  The rules are applied in addition
 to any existing C typing rules that apply to the cast.
 
-If \var{D} is not \ptrvoid\ or \unsafeptrvoid\ and \var{D} is
+If \var{D} is not \ptrvoid\ or \uncheckedptrvoid\ and \var{D} is
 \begin{itemize}
 \item \ptrT: the bounds of \var{e} are computed using the rules
 in Section~\ref{section:checking-nested-assignment-expressions}.
@@ -143,14 +144,14 @@ the destination \spanptr\ type.  At runtime, a new value of
 type \spanptrT\ with the value of \var{e} and \bounds{\var{lb}}{\var{ub}} will be created.
 \item \texttt{\var{T} *}: If the source type \var{S} is
 \begin{itemize}
-\item An unsafe pointer type (\texttt{*}), checking succeeds.
+\item An unchecked pointer type (\texttt{*}), checking succeeds.
 \item \ptrT, the checking succeeds. This handles the case where \var{T}
 is an incomplete type.
 \item Otherwise, the same rules are followed as for \ptrT.
 \end{itemize}
 \end{itemize}
 
-If \var{D} is \ptrvoid\ or \unsafeptrvoid\ and \var{S} is:
+If \var{D} is \ptrvoid\ or \uncheckedptrvoid\ and \var{S} is:
 \begin{itemize}
 \item A \ptr\ type, static checking always succeeds.
 \item An \arrayptr\ or \spanptr\ type: The bounds of \var{e} are computed:
@@ -163,11 +164,11 @@ succeeds.
 to that form).   It must be statically provable that \texttt{\var{e} >= \var{lb}}
 and that {\texttt{((char *) \var{ub}) - ((char *) e) >= 1}}.   
 \end{itemize}
-\item An unsafe pointer type:
+\item An unchecked pointer type:
 \begin{itemize}
 \item If \var{D} is \ptrvoid, the prior rule for an \arrayptr\ or \spanptr\ type is
 applied.
-\item If \var{D} is \unsafeptrvoid, checking always succeeds.
+\item If \var{D} is \uncheckedptrvoid, checking always succeeds.
 \end{itemize}
 \end{itemize}
 
@@ -247,16 +248,16 @@ to check at compile-time.
 
 A subtle point about the C cast operator and \dynamicboundscast\
 are that they allow {\em bounds-safe casts} of an expression
-\var{e} of unsafe pointer type to a \spanptr\ or
+\var{e} of unchecked pointer type to a \spanptr\ or
 \arrayptr\ type. This is provided that the bounds for \var{e}
-can be determined. Only a few kinds of expressions with unsafe pointer
+can be determined. Only a few kinds of expressions with unchecked pointer
 types have bounds that can be determined: address-of expressions
 involving variables and uses of array variables.
 
 \subsection{Examples}
 \label{section:pointer-cast-examples}
 
-Here are examples of C-style casts to safe pointers to
+Here are examples of C-style casts to checked pointers to
 constant-sized object. The static checking rules are straightforward
 to apply here.  The examples assume that integers are
 4 bytes in size:
@@ -277,29 +278,29 @@ void swizzle(ptr<int> p) {
 }
 \end{verbatim}
 
-\subsection{Implicit conversions involving safe pointers}
+\subsection{Implicit conversions involving checked pointers}
 \label{section:implicit-conversions}
 
 C allows implicit conversions at assignments, function call arguments,
 and conditional expressions.  The purpose of
 implicit conversions is to make programs shorter and easier to
 read.  This section defines implicit conversions that are
-allowed for safe pointer types.
+allowed for checked pointer types.
 
 The rules for checking bounds declarations are applied separately after 
 typechecking to check the integrity of bounds information.  During the 
 application of these rules, the implicit conversions are treated as
 though they were explicit C cast operations.
 
-\subsubsection{From unsafe pointers to safe pointers}
-An expression with an unsafe pointer type can be converted implicitly to an
-expression with a safe pointer type, provided that the referent types of the 
-unsafe pointer and the safe pointer are compatible.
+\subsubsection{From unchecked pointers to checked pointers}
+An expression with an unchecked pointer type can be converted implicitly to an
+expression with a checked pointer type, provided that the referent types of the
+unchecked pointer and the checked pointer are compatible.
 
 This can be done for the right-hand side of an assignment, a call argument,
 or an arm of a conditional expression.
 The type of the left-hand side of the assignment, the parameter, or the other 
-arm of the conditional expression must be the safe pointer type that is the
+arm of the conditional expression must be the checked pointer type that is the
 target of the implicit conversion.
 
 For now, compatibility is defined as the following:
@@ -313,44 +314,44 @@ complicated when referent types are function types, array types, or
 pointer types. {\em Discussion of a richer forms of compatibility
 is deferred for now}.
 
-C allows implicit conversions between \unsafeptrvoid\ and other pointer
-types. For now, implicit conversions from \unsafeptrvoid\ to safe pointer
+C allows implicit conversions between \uncheckedptrvoid\ and other pointer
+types. For now, implicit conversions from \uncheckedptrvoid\ to checked pointer
 types are allowed. This may be revised later when a design
 for checking type-safety of casts is complete.
 
-\subsubsection{From safe pointers to unsafe pointers}
+\subsubsection{From checked pointers to unchecked pointers}
 
-We must be very careful about implicit conversions from safe pointer
-types to unsafe pointer types.  These kinds of conversions could allow bounds checking to 
-be accidentally subverted in a quiet fashion. Implicit conversions from safe pointer types to 
-unsafe pointer types are allowed only at bounds-safe interfaces 
+We must be very careful about implicit conversions from checked pointer
+types to unchecked pointer types.  These kinds of conversions could allow bounds checking to
+be subverted accidentally in a quiet fashion. Implicit conversions from checked pointer types to
+unchecked pointer types are allowed only at bounds-safe interfaces
 (Section~\ref{section:function-bounds-safe-interfaces}).
 
-\subsubsection{From safe pointers to safe pointers}
+\subsubsection{From checked pointers to checked pointers}
 
-An expression with a safe pointer type can be converted implicitly to the same kind
-of safe pointer type with a \texttt{void} referent type.   
+An expression with a checked pointer type can be converted implicitly to the same kind
+of checked pointer type with a \texttt{void} referent type.
 This can be done for the right-hand side of an assignment, a call argument, 
 and an arm of a conditional expression.  
 The type of the left-hand side of the assignment, the parameter, or the other
 arm of the conditional expression
-must be the safe \void\ pointer type that is the target of the implicit
+must be the checked \void\ pointer type that is the target of the implicit
 conversion. For example, implicit conversions from 
 \ptrinst{\var{T}} to \ptrvoid\ and from \arrayptrinst{\var{T}} to \arrayptrvoid\ are allowed 
 at assignments. 
 
-Implicit conversions from safe pointers to \void\ to safe pointers to \var{T} are not allowed.
+Implicit conversions from checked pointers to \void\ to checked pointers to \var{T} are not allowed.
 The philosophy behind this is the same one that is used in C++: places where type-safety
 can be compromised by a cast should be explicit in the code.
 
-\subsubsection{Between safe pointers and integers}
+\subsubsection{Between checked pointers and integers}
 
-The null pointer (0) can be converted implicitly to any safe pointer type.   
-A safe pointer can be converted implicitly to the \texttt{\_Bool} type.
+The null pointer (0) can be converted implicitly to any checked pointer type.
+A checked pointer can be converted implicitly to the \texttt{\_Bool} type.
 
 Some C compilers extend C by allowing implicit conversions between pointers
 and integers or between pointers to incompatible types.  Implicit conversions
-from integers to safe pointers are typically not useful in Checked C because
+from integers to checked pointers are typically not useful in Checked C because
 the checking of bounds declarations fails or the resulting pointer cannot
 be used to access memory.   The rules for checking bounds declarations only
 allow the target type to be \arrayptr\ type and the bounds of the expression to be
@@ -377,7 +378,7 @@ array_ptr<char> pax : count(5) : &x;     // fails to check: source not large eno
 array_ptr<int> pdata : count(4) = data;
 \end{verbatim}
 
-Incorrect conversions of unsafe pointers with no bounds information
+Incorrect conversions of unchecked pointers with no bounds information
 will also be rejected.  In the following example, the bounds for 
 \texttt{random()} will be computed as \boundsnone, which does
 not match \boundscount{1}.
@@ -389,7 +390,7 @@ void f() {
 }
 \end{verbatim}
 
-\section{Bounds-safe interfaces to existing unsafe functions and variables}
+\section{Bounds-safe interfaces to existing unchecked functions and variables}
 \label{section:function-bounds-safe-interfaces}
 
 The new pointer types capture specific properties of pointers. One would
@@ -422,47 +423,47 @@ The code will no longer compile. C does not have method overloading, so
 we cannot simply define multiple overloaded versions of \texttt{memcpy}. That
 would also duplicate code and potentially increase program sizes.
 The reverse problem also exists: suppose the signature for \texttt{memcpy} is not
-updated. Then every ``safe'' method that calls memcpy would need to cast
-the arguments to unsafe pointer types.
+updated. Then every ``checked'' method that calls memcpy would need to cast
+the arguments to unchecked pointer types.
 
 Given that we may not be able to change the pointer types of existing
 APIs, we need to adopt an approach that supports backwards
-compatibility, enables new safe code to be written easily, and maintains
-the safety of new code.
+compatibility, enables new checked code to be written easily, and maintains
+the checking of new code.
 
 We address this by:
 
 \begin{enumerate}
 \item
   Allowing programmers to declare bounds-safe interfaces to code and
-  data structures that use unsafe pointers. A bounds-safe interface for
-  a function, for example, describes bounds for unsafe pointer
+  data structures that use unchecked pointers. A bounds-safe interface for
+  a function, for example, describes bounds for unchecked pointer
   parameters.   Type checking is altered to insert implicit conversions
   between pointer types when needed.
 \item
   In checked scopes, code is limited to using pointer types that are 
-  safe pointer types or unsafe pointer types that have bounds-safe interfaces.  
+  checked pointer types or unchecked pointer types that have bounds-safe interfaces.
   This makes the code in checked scopes straightforward to understand:
-  the unsafe pointer types are regarded as safe pointer types, all memory 
+  the unchecked pointer types are regarded as checked pointer types, all memory
   accesses are bounds checked or in bounds, and bounds-safe interfaces are trusted
   and respected.
 \item
-  In unchecked scopes, safe and unsafe pointer types can be
+  In unchecked scopes, checked and unchecked pointer types can be
   be intermixed within expressions.  When that happens, the bounds-safe
   interfaces are used during checking of bounds for determining bounds
   of expressions and the required bounds for expressions. 
   Section~\ref{section:implicit-conversions} already
-  explained when implicit conversions from unsafe pointer types to safe pointer
+  explained when implicit conversions from unchecked pointer types to checked pointer
   types may be inserted.   Implicit conversions of rvalue expressions 
-  from safe pointer types to unsafe pointer types are also inserted when
+  from checked pointer types to unchecked pointer types are also inserted when
   there are bounds-safe interfaces that describe the bounds requirements.
 \end{enumerate}
 
-Functions that have parameters with unsafe pointer types or that return
-values with unsafe pointer types can have bounds declared for the unsafe
-pointer parameters or the unsafe pointer return value. Bounds must be
-declared for all parameters with unsafe pointer types and the return
-value, if it has an unsafe pointer type. In the case where a parameter
+Functions that have parameters with unchecked pointer types or that return
+values with unchecked pointer types can have bounds declared for the unchecked
+pointer parameters or the unchecked pointer return value. Bounds must be
+declared for all parameters with unchecked pointer types and the return
+value, if it has an unchecked pointer type. In the case where a parameter
 has \texttt{ptr} type, this can be declared specially.
 
 Here is a bounds-safe interface for \texttt{memcpy}:
@@ -473,13 +474,13 @@ void *memcpy(void *dest : byte_count(len), const void *src : byte_count(len),
 \end{verbatim}
 
 The correctness of bounds information is enforced at compile-time when
-memcpy is passed safe pointer arguments. It is not enforced when memcpy
-is passed unsafe pointer arguments.
+memcpy is passed checked pointer arguments. It is not enforced when memcpy
+is passed unchecked pointer arguments.
 
-Similarly, for data structures, members with unsafe pointer types can
+Similarly, for data structures, members with unchecked pointer types can
 have bounds declared. If bounds are declared for one member of a
-structure with an unsafe pointer type, they must be declared for all
-members with unsafe pointer types.
+structure with an unchecked pointer type, they must be declared for all
+members with unchecked pointer types.
 
 Here are the bounds for a structure that is a counted buffer of
 characters.
@@ -492,63 +493,63 @@ struct S {
 
 We may have a method that takes a counted buffer of characters and
 counts the number of instances of a specific character. The \texttt{ptr}
-declaration can be used to declare an unsafe pointer to a singleton
+declaration can be used to declare an unchecked pointer to a singleton
 object of a type:
 \begin{verbatim}
 int count_char(S *str where ptr, char arg);
 \end{verbatim}
 
-Variables at external scope with unsafe pointer types may also have 
+Variables at external scope with unchecked pointer types may also have
 bounds declared for them.   The declarations must follow the 
 rules in Section~\ref{section:external-scope-variables}.
 
-It is important to understand that the \emph{semantics of unsafe
+It is important to understand that the \emph{semantics of unchecked
 pointers does not change in unchecked scopes even when bounds are
 declared for the pointers}. The declared bounds are used  for expressions
-that mix safe and unsafe pointer types. Unsafe pointer dereferences do not
+that mix checked and unchecked pointer types. Unchecked pointer dereferences do not
 have bounds checks added to them. A function that declares a bounds-safe 
-interface and whose body does not use safe pointer
+interface and whose body does not use checked pointer
 types is compiled as though the bounds-safe interface has been
 stripped from its source code.
 
 \subsection{Type checking}
 
-Bounds-safe interfaces allow unsafe pointer types to be used
-where safe pointer types with compatible referent types are expected
+Bounds-safe interfaces allow unchecked pointer types to be used
+where checked pointer types with compatible referent types are expected
 and {\it vice versa}.
 To handle this, implicit pointer conversions are inserted during type checking.
-Section~\ref{section:implicit-conversions} covered implicit conversions from unsafe pointer types to safe pointer types.
+Section~\ref{section:implicit-conversions} covered implicit conversions from unchecked pointer types to checked pointer types.
 
-Implicit conversions from safe pointer types to unsafe pointer types
+Implicit conversions from checked pointer types to unchecked pointer types
 with compatible referent types are allowed exactly at the uses of functions,
-variables, or members with a  bounds-safe interface.  The conversions are done for rvalue expressions by inserting C cast operators to the desired unsafe types.
+variables, or members with a  bounds-safe interface.  The conversions are done for rvalue expressions by inserting C cast operators to the desired unchecked types.
 They may be done at:
 \begin{itemize}
 \item Function call arguments: If the function being called has a 
-      bounds-safe interface for unsafe pointer type arguments, a parameter type 
-      has an unsafe pointer type, and the corresponding argument expression has a safe
+      bounds-safe interface for unchecked pointer type arguments, a parameter type
+      has an unchecked pointer type, and the corresponding argument expression has a checked
       pointer type whose referent type is compatible with the parameter
       referent type, the argument expression will be converted implicitly to the 
-      unsafe pointer type.
+      unchecked pointer type.
 \item Assignments to a variable with external scope: if the variable being
-     assigned to has an unsafe pointer type and a bound-safe interface and the
-     right-hand side expression has a safe pointer whose referent type is
+     assigned to has an unchecked pointer type and a bound-safe interface and the
+     right-hand side expression has a checked pointer whose referent type is
      compatible with the
      variable referent type, the right-hand side expression will be converted
-     implicitly to the unsafe pointer type.
+     implicitly to the unchecked pointer type.
 \item
    Member assignments: a similar conversion is done for member assignments.
 \end{itemize}
 
-Implicit conversions at bounds-safe interfaces are allowed from safe pointer types to 
-\unsafeptrvoid.  This rule is likelty to change in the future.  There is not a  design for
+Implicit conversions at bounds-safe interfaces are allowed from checked pointer types to
+\uncheckedptrvoid.  This rule is likely to change in the future.  There is not a  design for
 checking type-safety of casts yet and the design will amost certainly affect 
-\unsafeptrvoid\ casts.
+\uncheckedptrvoid\ casts.
 
 Only one implicit pointer conversion is allowed for an expression at a bounds-safe
 interface.  For example, an expression will not be
-coerced implicitly from \ptrinst{\var{S}} to \unsafeptrvoid\ to
-\unsafeptrinst{\var{T}}, where \var{S} and \var{T} are different types.
+coerced implicitly from \ptrinst{\var{S}} to \uncheckedptrvoid\ to
+\uncheckedptrinst{\var{T}}, where \var{S} and \var{T} are different types.
 
 
 \subsection{Checking bounds declarations}
@@ -559,16 +560,16 @@ only small changes to check code with bounds-safe interfaces.  The
 checking is done after any implicit pointer conversions have been
 inserted.
 \begin{itemize}
-\item Contexts are extended to include unsafe pointer variables with
+\item Contexts are extended to include unchecked pointer variables with
       bounds-safe interfaces
 \item Inference of bounds of expressions (Section~\ref{section:inferring-expression-bounds}) incorporates information from bounds-safe interfaces:
 \begin{itemize}
 \item Uses of variables (Section~\ref{section:checking-variables}): 
-      if a variable with an unsafe pointer type is used and the context has
+      if a variable with an unchecked pointer type is used and the context has
       a bounds for the variable, the bounds in the context are used as the bounds
       for the variable.
 \item Function calls (Section~\ref{section:inferring-bounds-for-function-calls}): 
-      the rules in this section are also applied when a function returns an unsafe 
+      the rules in this section are also applied when a function returns an unchecked
       pointer value and the return value has a bounds-safe interface.
 \end{itemize}
 \item The checking that an expression statement, declaration, or bundled
@@ -578,7 +579,7 @@ inserted.
 \item In unchecked contexts, all variables with bounds-safe interfaces
       that are modified by an assignment within the statement, declaration,
       or bundled block, where the right-hand side expression
-      is implicitly converted from a safe pointer type to an unsafe pointer type.
+      is implicitly converted from a checked pointer type to an unchecked pointer type.
 \end{itemize}
 For the included variables, bounds are tracked through the statement or
 bundled block.
@@ -588,7 +589,7 @@ bundled block.
 \begin{itemize}
 \item In checked contexts.
 \item In unchecked contexts, when one or more argument expressions have been 
-      converted implicitly to unsafe pointer types.
+      converted implicitly to unchecked pointer types.
 \end{itemize}
 The parameters are included by adding their bounds-safe interfaces to the
 declared bounds in the constructed \keyword{where} clauses.
@@ -598,14 +599,14 @@ The checking for assignments and function calls has some interesting
 implications in unchecked contexts.  It is possible to have a statement, 
 a declaration, or a bundled block that mixes different kinds of pointers
 in assignments to the same  variable.  
-Some right-hand sides could have safe pointer types and others
-could have unsafe pointer types.  This is a programming practice that is discouraged.
+Some right-hand sides could have checked pointer types and others
+could have unchecked pointer types.  This is a programming practice that is discouraged.
 Nevertheless, the bounds declarations will be checked no matter which
 kind of assignment is the last one.  This implies that if the last 
 assignment has an unasfe pointer-typed right-hand side, it will still need
 to have valid bounds.   It is also possible to mix argument expressions with 
-safe and unsafe  pointer types in one function call.  The checking of bounds
-for function arguments is done for all arguments, so this also implies that the unsafe
+checked and unchecked  pointer types in one function call.  The checking of bounds
+for function arguments is done for all arguments, so this also implies that the unchecked
 pointer-typed expressions will need to have valid bounds.
 
 \subsection{Examples}
@@ -619,7 +620,7 @@ void copy(array_ptr<int> dest : count(len),
     // Even though this is an unchecked context, the function call
     // arguments will be checked to make sure that they meet the
     // bounds requirements of memcpy.  This is because the argument
-    // expressions have safe pointer types.
+    // expressions have checked pointer types.
     memcpy(dest, src, len * sizeof(int));
 }
  
@@ -640,7 +641,7 @@ void bad_copy(int *dest,
               array_ptr<int> src : count(len), int len)
 {
     // dest, src will be converted implicitly to void * pointers.
-    // Because an argument had a safe pointer type, the function call
+    // Because an argument had a checked pointer type, the function call
     // will be checked to make sure parameters meet the bounds
     // requirements.  This will fail because dest has no bounds.
     memcpy(dest, src, len * sizeof(int));
@@ -653,10 +654,10 @@ void subtle_copy(int *dest,
                  array_ptr<int> src : count(len), int len)
 {
     // This function call will not be checked for bounds
-    // requirements because no arguments have safe pointer
+    // requirements because no arguments have checked pointer
     // types.  This shows both that the programmer has control
     // over checking by using types and why checked contexts
-    // should be used with safe pointers when possible (perhaps
+    // should be used with checked pointers when possible (perhaps
     // the programmer did not want to do this).
     memcpy(dest, (void *) src, len * sizeof(int));
 }

--- a/spec/bounds_safety/introduction.tex
+++ b/spec/bounds_safety/introduction.tex
@@ -61,7 +61,7 @@ Checked C addresses the bounds checking problem for C by:
 \begin{itemize}
 \item
   Introducing different pointer types to capture the different ways in
-  which pointers are used. The unsafe C pointer type \texttt{*} is kept
+  which pointers are used. The unchecked C pointer type \texttt{*} is kept
   and three new pointer types are added: one for pointers that are never
   used in pointer arithmetic (\ptr), one for \emph{array pointer
   types} (\arrayptr) that are involved in pointer arithmetic,
@@ -96,22 +96,22 @@ Checked C addresses the bounds checking problem for C by:
   to members maintain the member bounds.
 \item
   Introducing bounds-safe interfaces to address the problem of
-  interoperation between safe code and unsafe code. A bounds-safe
-  interface describes the safe interface to unsafe code by declaring
-  bounds for unsafe pointers in function signatures and data structures.
-  Because it describes a boundary, it has to be ``safe'' and ``unsafe''
+  interoperation between checked code and unchecked code. A bounds-safe
+  interface describes the checked interface to unchecked code by declaring
+  bounds for unchecked pointers in function signatures and data structures.
+  Because it describes a boundary, it has to be ``checked'' and ``unchecked''
   at the same time, depending on what kind of code is using it. The
-  interface is trusted in safe code (code that uses only safe pointer types).
+  interface is trusted in checked code (code that uses only checked pointer types).
   Proper usage is enforced via checking at compile time and runtime. For
-  code that uses only unsafe pointer types, the interface is descriptive and 
+  code that uses only unchecked pointer types, the interface is descriptive and
   not enforced by
   language checking. This provides a way to upgrade existing code to
-  provide a safe interface without breaking existing users of the code.
+  provide a checked interface without breaking existing users of the code.
 \item
   Introducing checked program scopes, where bounds checking is the
   default behavior. In a checked program scope, definitions of variables
-  and functions can use safe pointer types and cannot use unsafe pointer
-  types. Declarations involving unsafe pointer types must provide
+  and functions can use checked pointer types and cannot use unchecked pointer
+  types. Declarations involving unchecked pointer types must provide
   bounds-safe interfaces. Checked program scopes avoid problems with
   subtle misuse of bounds-safe interfaces.
 \item
@@ -192,10 +192,10 @@ statements later that \texttt{x == z}, even though it may be true at
 that point in the program. This is taking advantage of the fact that
 checking a proof is usually much easier than creating the proof.
 
-Establishing the safety of pointer operations is just the first step in
+Establishing the bounds-safety of pointer operations is just the first step in
 establishing type safety for C programs. There are other ways which C
 programs may fail. C programs may incorrectly deallocate memory that is
-still in use, do incorrect unsafe pointer casts, or have concurrency
+still in use, do incorrect type-unsafe pointer casts, or have concurrency
 races that tear data structures. Addressing these problems is beyond the
 scope of this technical report. For now, it is assumed that programs are
 correct in these other aspects.
@@ -205,7 +205,7 @@ design, we mocked up modifying a subset of the OpenSSL
 code base \cite{OpenSSL2015} to be bounds-safe .  
 We created C++ templates for the new pointer types and modified OpenSSL to 
 compile as valid C++ code.
-We hand-edited about 11,000 lines of the code to use safe pointer
+We hand-edited about 11,000 lines of the code to use checked pointer
 types with full bounds annotations.  We used macros to encapsulate 
 the bounds annotations so that they could be elided from the code
 and OpenSSL compiled and tested using the new types.  We also modified the
@@ -220,11 +220,11 @@ Second, in most cases, declaring bounds at declarations was sufficient for
 tracking the bounds of variables.  Large blocks of code 
 remained unchanged, which matches the observations of the
 Cyclone project \cite{Jim2002}, an earlier research 
-effort to create a safe version of C.
+effort to create a type-safe version of C.
 Third, the expressions allowed in declaring
 bounds needed to be rich.  Fourth, pointer casts were used
 fairly extensively, but often times it was obvious that the casts were
-safe with respect to bounds.  The existing bounds could be modified
+correct with respect to bounds.  The existing bounds could be modified
 easily to be appropriate for the new referent type of the pointer.
 Fifth, it was clear that there needed
 to be a graceful way of interoperating with existing libraries that could
@@ -277,14 +277,14 @@ Here are the principles that are followed to extend C to support bounds checking
 \item
   Enable incremental use. Real systems are large and complicated, with
   hundreds of thousands and millions of lines of code. The teams that
-  work on those systems will adopt safe pointer operations over time,
-  not all at once, so incremental use of safe pointer operations will be
+  work on those systems will adopt checked pointer operations over time,
+  not all at once, so incremental use of checked pointer operations will be
   supported. Teams will prefer incremental conversion paths because of
   practical matters such as reducing risk, fixing existing bugs
   identified by introducing bounds checking, maintaining system
   stability, and understanding performance effects. Even though
   incremental use will be supported, it is not the end goal. We believe
-  that benefits of using safe pointer operations will be modest until
+  that benefits of using checked pointer operations will be modest until
   almost an entire system is converted. At that point, we expect a
   qualitative increase in system reliability and programmer
   productivity.
@@ -321,8 +321,8 @@ a roadmap for the different audiences.
 Chapter~\ref{chapter:core-extensions} describes
 the new pointer types and the new array types, including syntax,
 semantics, and error conditions. It also covers other extensions to C
-semantics. One extension is the introduction of safe program scopes to
-prevent inadvertent use of unsafe types. Another extension is a
+semantics. One extension is the introduction of checked program scopes to
+prevent inadvertent use of unchecked types. Another extension is a
 refinement of C's notion of undefined behavior. We wish to maintain
 bounds safety even in the face of integer overflow, which is a
 widespread possibility in C programs. This requires a more nuanced
@@ -367,10 +367,10 @@ This inferred information is then used to validate that declarations and
 statements correctly declare bounds and maintain the bounds information.
 
 Chapter~\ref{chapter:interoperation} covers interoperation between 
-safe and unsafe code. It covers
-conversions between safe and unsafe pointers, as well as the new kinds
-of pointers. It pins down the notion of safe code and unsafe code.
-Finally, it covers bounds-safe interfaces in depth.
+checked and unchecked code. It covers conversions between checked and
+unchecked pointers, as well as conversions between the new kinds of checked pointers.
+It pins down the notion of checked code  and unchecked code. Finally, it covers
+bounds-safe interfaces in depth.
 
 Chapter~\ref{chapter:structure-bounds} extends these ideas from variables to data 
 structures by
@@ -471,7 +471,8 @@ and Chapters~\ref{chapter:lessons} and \ref{chapter:design-alternatives}.
 \section{Acknowledgements}
 
 This design has benefited from many discussions with Weidong Cui, Gabriel Dos Reis, 
-Chris Hawblitzel, Galen Hunt, Shuvendu Lahiri, and Reuben Olinsky.  We thank them 
-for their contributions to the design.
+Chris Hawblitzel, Galen Hunt, Shuvendu Lahiri, and Reuben Olinsky.  The design has
+benefited also from feedback from Michael Hicks, Greg Morrisett, Andrew Ruef, and Jonghyun
+Park. We thank them for their contributions to the design.
 
 

--- a/spec/bounds_safety/lessons.tex
+++ b/spec/bounds_safety/lessons.tex
@@ -47,16 +47,16 @@ systems. First, it is not feasible in practice to require widespread
 data layout changes, as CCured did. Second, this means that use of
 program invariants and/or runtime system support will be required to
 establish that pointer uses are in bounds. Third, it can be arbitrarily
-hard to show the type safety statically of unsafe low-level systems
-code. The code may be safe at runtime. A programmer may intuitively know
-that it is safe and be able to argue informally for correctness.
+hard to show the type safety statically of low-level systems
+code. The code may be type-safe at runtime. A programmer may intuitively know
+that it is type-safe and be able to argue informally for correctness.
 However, writing down the invariants may be hard and may require deep
 knowledge of program verification techniques. It may also lead to
 invariants that are longer and more complicated than the original code.
 It may be better for a programmer to just rewrite the code to be type
 safe.
 
-Extensions for safe pointer operations will require a trade-off between
+Extensions for checked pointer operations will require a trade-off between
 dynamic techniques for checking pointer bounds (which are easy to reason
 about and understand, but require data layout changes) and static
 techniques (which may not be easy to reason about and understand, but do
@@ -354,7 +354,7 @@ safety requirements. This would be an easy and low-risk improvement to
 the safety of C programs.
 
 For pointers where pointer arithmetic is allowed, a combination of
-dynamic and static techniques will be needed to ensure safe pointer
+dynamic and static techniques will be needed to ensure bounds-safe pointer
 operations. Dynamic techniques that change pointer representations allow
 succinct and clear code, at the expense of changing data layout and
 causing problems with interoperation and likely efficiency. Static

--- a/spec/bounds_safety/makefile
+++ b/spec/bounds_safety/makefile
@@ -1,6 +1,5 @@
 PAPERNAME=checkedc
 FILES = abstract.tex \
-        array-view-compilation.tex \
         checking-variable-bounds.tex \
         core-extensions.tex \
         design-alternatives.tex \
@@ -11,10 +10,11 @@ FILES = abstract.tex \
         open-issues.tex \
         pointers-to-pointers.tex \
         simple-invariants.tex \
+        span-compilation.tex \
         structure-bounds.tex \
         variable-bounds.tex \
         sources.bib \
-	checkedc.tex
+        checkedc.tex
 
 all: $(PAPERNAME).pdf
 

--- a/spec/bounds_safety/open-issues.tex
+++ b/spec/bounds_safety/open-issues.tex
@@ -36,10 +36,11 @@ the statement.  Also add wording to allow a bundle block to do this.
 \item
   Pointer casts that produce incorrectly aligned pointers have undefined
   behavior, according to the C11 standard. This hole should be filled in
-  for safe pointer types. For safe pointer types, we should specify
+  for checked pointer types. For checked pointer types, we should specify
   either (1) dereferencing an incorrectly aligned pointer shall cause a
   runtime error or (2) the cast itself shall check any alignment
-  requirements. For case 1, note that safe pointer arithmetic is already
+  requirements. For case 1, note that pointer arithmetic for checked pointer types
+  is already
   defined to preserve misalignment.
 \end{itemize}
 

--- a/spec/bounds_safety/pointers-to-pointers.tex
+++ b/spec/bounds_safety/pointers-to-pointers.tex
@@ -16,7 +16,7 @@ to assign through pointers to structures, and to read from pointers to structure
 \item Passing data by-reference to functions.  C does not provide by-reference
 parameters.  Programmers pass data by-reference by using pointers explicitly.
 To pass data of type \var{T} by reference, a programmer creates a parameter
-with type \var{T *}.  Using safe pointers, a programmer create a parameter
+with type \var{T *}.  Using checked pointers, a programmer create a parameter
 with type \ptrT.
 \item Taking the addresses of variables.  In C, programmers may take the
 addresses of variables.  Typically, this is done to be pass data by-reference.
@@ -28,16 +28,16 @@ must be constrained so that bounds-safety is not accidentally broken.
 
 The term ``referent data'' will refer to the data that can be accessed
 directly through a pointer.  The data may be an integer or floating-point number, a structure,
-a pointer, or an array of data.   Any safe pointers in data must be initialized
+a pointer, or an array of data.   Any checked pointers in data must be initialized
 before the pointers are used.
 
 For variables, this can be enforced using a static 
-analysis of variables with safe pointer types that point to data with safe 
+analysis of variables with checked pointer types that point to data with checked
 pointer types. For example, the Cyclone dialect of C \cite{Jim2002} did this
 and languages like Java and C\# have rules for ensuring that variables
 are definitely assigned before they are used.
 For a variable of \arrayptr\ data, the compiler will insert code for 
-initializing safe pointers in the data automatically to \texttt{0}, which is always
+initializing checked pointers in the data automatically to \texttt{0}, which is always
 a valid pointer.    
 
 For heap-allocated data, we can require that allocators
@@ -239,7 +239,7 @@ a unique pointer to memory that no one else has \cite{Jim2002}.
 initialization state declaration is valid after a statement.  We leave 
 the rules to be worked out later.
 \item Additional static checking rules will be added to ensure the
-safety of casts to safe pointer types that have pointer types embedded
+correctness with respect to bounds of casts to checked pointer types that have pointer types embedded
 within them.
 \end{itemize}
 
@@ -253,7 +253,7 @@ where return_value : byte_count(len) && return_value: _uninit_data;
 void *calloc(size_t num, size_t size)
 where return_value : byte_count(num * size)  && return_value : _zero_data
 \end{verbatim}
-A cast from the result of a \texttt{malloc} call to a safe pointer type with pointer types
+A cast from the result of a \texttt{malloc} call to a checked pointer type with pointer types
 would propagate the  \texttt{\_uninit} predicate:
 \begin{verbatim}
 struct S {

--- a/spec/bounds_safety/structure-bounds.tex
+++ b/spec/bounds_safety/structure-bounds.tex
@@ -530,12 +530,12 @@ true at the point of the \keyword{holds} declaration.
 Just as existing functions can have bounds-safe interfaces declared for
 them, existing structure types can have bounds-safe interfaces declared
 for them. This allows safe code to use those data structures and for
-those uses to be checked. Existing unsafe code is unchanged.
+those uses to be checked. Existing unchecked code is unchanged.
 
 To create a bound-safe interface for a structure type, a programmer
-declares member bounds for structure members with unsafe pointer types.
-A programmer may also declare whether an unsafe pointer should be
-treated as \ptr\ type by safe code.
+declares member bounds for structure members with unchecked pointer types.
+A programmer may also declare whether an unchecked pointer should be
+treated as \ptr\ type by checked code.
 
 Here is a bound-safe interface for a structure that is a counted buffer
 of characters:
@@ -560,16 +560,16 @@ struct BinaryNode {
 \end{verbatim}
 
 If bounds information is declared for one member of a structure with an
-unsafe pointer type, it must be declared for all other members of the
-structure with unsafe pointer types.
+unchecked pointer type, it must be declared for all other members of the
+structure with unchecked pointer types.
 
-It is important to understand that the \emph{semantics of unsafe
+It is important to understand that the \emph{semantics of unchecked
 pointers in unchecked contexts does not change even when bounds are declared 
-for the pointers}. The declared bounds are used only by safe code that uses the
-data structure, when storing safe pointers into the data structure, and
-when converting unsafe pointers data structures, and when reading safe
-pointers from the data structure unsafe functions or uses unsafe data
-structures.
+for the pointers}. The declared bounds are used only by checked code that uses the
+data structure, when storing checked pointers into the data structure, and when converting
+unchecked pointers read from the data structure to checked pointers.  Code in unchecked
+contexts that uses only unchecked pointer types is compiled as though the bounds-safe
+interface has been stripped from the source code.
 
 \section{Extending checking validity of bounds}
 \label{section:checking-bounds-with-structures}

--- a/spec/bounds_safety/variable-bounds.tex
+++ b/spec/bounds_safety/variable-bounds.tex
@@ -919,7 +919,7 @@ The standard C library functions for \texttt{malloc}, \texttt{memcmp}, and
 \texttt{memcpy} will be
 given bounds-safe interfaces to avoid breaking existing code as
 described in Section~\ref{section:function-bounds-safe-interfaces}. 
-However, if they were to return safe pointer
+However, if they were to return checked pointer
 types, their bounds declarations would be:
 
 \begin{verbatim}
@@ -1562,7 +1562,7 @@ must do the following checks:
   count is less than the upper bound as well.
 \end{itemize}
 
-When retrofitting existing code to use safe pointers, the code may be
+When retrofitting existing code to use checked pointers, the code may be
 unprepared for overflow or wraparound to happen during allocation. This
 suggests that uses of \texttt{malloc} should be replaced by slightly
 higher-level functions that takes the element count and the size of


### PR DESCRIPTION
We have been using the terminology safe and unsafe to describe the new
pointer types and the existing C pointer type, respectively.  The term
unsafe has negative connotations.  The term safe is also imprecise.  The
design only addresses bounds safety and does not yet address memory
lifetime safety or type casts that allow corruption of bounds information.
We are switching to the terms checked and unchecked instead.

This mostly addresses issue #11.  We still need to make sure that we are 
being clear in the text about what is not being checked.
