### PR TITLE
Tests and changes for new #pragma CHECKED_SCOPE functionality.

### DIFF
--- a/include/arpa/inet_checked.h
+++ b/include/arpa/inet_checked.h
@@ -5,18 +5,28 @@
 // These are POSIX-only                                                //
 /////////////////////////////////////////////////////////////////////////
 
+#ifndef __cplusplus
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE off
+#endif
+
 #include <arpa/inet.h>
+
+#ifndef __cplusplus
+#pragma CHECKED_SCOPE pop
+#endif
 
 #ifndef __cplusplus
 #ifndef __INET_CHECKED_H
 #define __INET_CHECKED_H
 
+#pragma CHECKED_SCOPE push
 #pragma CHECKED_SCOPE ON
 
 extern in_addr_t inet_addr (const char *__cp : itype(_Nt_array_ptr<const char>)) __THROW;
 
 
-#pragma CHECKED_SCOPE OFF
+#pragma CHECKED_SCOPE pop
 
 #endif
 #endif

--- a/include/assert_checked.h
+++ b/include/assert_checked.h
@@ -4,13 +4,22 @@
 //                                                                     //
 /////////////////////////////////////////////////////////////////////////
 
+#ifndef __cplusplus
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE off
+#endif
 
 #include <assert.h>
+
+#ifndef __cplusplus
+#pragma CHECKED_SCOPE pop
+#endif
 
 #ifndef __cplusplus
 #ifndef __ASSERT_CHECKED_H
 #define __ASSERT_CHECKED_H
 
+#pragma CHECKED_SCOPE push
 #pragma CHECKED_SCOPE ON
 
 #if defined(_WIN32) || defined(_WIN64)
@@ -29,7 +38,7 @@ __THROW __attribute__ ((__noreturn__));
 
 #endif
 
-#pragma CHECKED_SCOPE OFF
+#pragma CHECKED_SCOPE pop
 
 #endif  // guard
 #endif  // no c++

--- a/include/errno_checked.h
+++ b/include/errno_checked.h
@@ -3,13 +3,22 @@
 //                                                                    //
 ////////////////////////////////////////////////////////////////////////
 
+#ifndef __cplusplus
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE off
+#endif
+
 #include <errno.h>
+
+#ifndef __cplusplus
+#pragma CHECKED_SCOPE pop
+#endif
 
 #ifndef __cplusplus
 #ifndef __ERRNO_CHECKED_H
 #define __ERRNO_CHECKED_H
 
-
+#pragma CHECKED_SCOPE push
 #pragma CHECKED_SCOPE ON
 
 #if defined(_WIN32) || defined(_WIN64)
@@ -18,7 +27,7 @@ __declspec(dllimport) int* __cdecl _errno(void) : itype(_Ptr<int>);
 extern int* __errno_location(void) : itype(_Ptr<int>) __THROW __attribute_const__;
 #endif
 
-#pragma CHECKED_SCOPE OFF
+#pragma CHECKED_SCOPE pop
 
 #endif // guards
 #endif // c++

--- a/include/fenv_checked.h
+++ b/include/fenv_checked.h
@@ -6,12 +6,22 @@
 // specification.                                                     //
 ////////////////////////////////////////////////////////////////////////
 
+#ifndef __cplusplus
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE off
+#endif
+
 #include <fenv.h>
+
+#ifndef __cplusplus
+#pragma CHECKED_SCOPE pop
+#endif
 
 #ifndef __cplusplus
 #ifndef __FENV_CHECKED_H
 #define __FENV_CHECKED_H
 
+#pragma CHECKED_SCOPE push
 #pragma CHECKED_SCOPE ON
 
 int fesetexceptflag(const fexcept_t *flagp : itype(_Ptr<const fexcept_t>),
@@ -21,7 +31,7 @@ int feholdexcept(fenv_t *envp : itype(_Ptr<fenv_t>));
 int fesetenv(const fenv_t *envp : itype(_Ptr<const fenv_t>));
 int feupdateenv(const fenv_t *envp : itype(_Ptr<const fenv_t>));
 
-#pragma CHECKED_SCOPE OFF
+#pragma CHECKED_SCOPE pop
 
 #endif
 #endif

--- a/include/inttypes_checked.h
+++ b/include/inttypes_checked.h
@@ -6,13 +6,23 @@
 // specification.                                                      //
 /////////////////////////////////////////////////////////////////////////
 
+#ifndef __cplusplus
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE off
+#endif
+
 #include <stddef.h> // define wchar_t for wcstoimax and wcstoumax
 #include <inttypes.h>
+
+#ifndef __cplusplus
+#pragma CHECKED_SCOPE pop
+#endif
 
 #ifndef __cplusplus
 #ifndef __INTTYPES_CHECKED_H
 #define __INTTYPES_CHECKED_H
 
+#pragma CHECKED_SCOPE push
 #pragma CHECKED_SCOPE ON
 
 _Unchecked
@@ -42,7 +52,7 @@ uintmax_t wcstoumax(const wchar_t * restrict nptr :
                       itype(restrict _Ptr<_Nt_array_ptr<wchar_t>>),
                     int base);
 
-#pragma CHECKED_SCOPE OFF
+#pragma CHECKED_SCOPE pop
 
 #endif // guard
 #endif // no c++

--- a/include/math_checked.h
+++ b/include/math_checked.h
@@ -6,12 +6,22 @@
 // specification.                                                      //
 /////////////////////////////////////////////////////////////////////////
 
+#ifndef __cplusplus
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE off
+#endif
+
 #include <math.h>
+
+#ifndef __cplusplus
+#pragma CHECKED_SCOPE pop
+#endif
 
 #ifndef __cplusplus
 #ifndef __MATH_CHECKED_H
 #define __MATH_CHECKED_H
 
+#pragma CHECKED_SCOPE push
 #pragma CHECKED_SCOPE ON
 
 double frexp(double value, int *exp : itype(_Ptr<int>));
@@ -31,7 +41,7 @@ double nan(const char *t : itype(_Nt_array_ptr<const char>));
 float nanf(const char *t : itype(_Nt_array_ptr<const char>));
 long double nanl(const char *t : itype(_Nt_array_ptr<const char>));
 
-#pragma CHECKED_SCOPE OFF
+#pragma CHECKED_SCOPE pop
 
 #endif //guard
 #endif // no c++

--- a/include/signal_checked.h
+++ b/include/signal_checked.h
@@ -3,13 +3,23 @@
 // take pointer arguments.                                             //
 /////////////////////////////////////////////////////////////////////////
 
+#ifndef __cplusplus
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE off
+#endif
+
 #include <signal.h>
+
+#ifndef __cplusplus
+#pragma CHECKED_SCOPE pop
+#endif
 
 #ifndef __cplusplus
 #ifndef __SIGNAL_CHECKED_H
 #define __SIGNAL_CHECKED_H
 
-#pragma CHECKED_SCOPE ON
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE on
 
 _Unchecked
 void (*signal(int sig,
@@ -18,7 +28,7 @@ void (*signal(int sig,
               ) : itype(_Ptr<void (int)>) // bounds-safe interface for signal return
      )(int);
 
-#pragma CHECKED_SCOPE OFF
+#pragma CHECKED_SCOPE pop
 
 #endif
 #endif

--- a/include/stdio_checked.h
+++ b/include/stdio_checked.h
@@ -8,13 +8,23 @@
 // TODO: Better Support for _FORTIFY_SOURCE > 0                        //
 /////////////////////////////////////////////////////////////////////////
 
+#ifndef __cplusplus
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE off
+#endif
+
 #include <stdio.h>
+
+#ifndef __cplusplus
+#pragma CHECKED_SCOPE pop
+#endif
 
 #ifndef __cplusplus
 #ifndef __STDIO_CHECKED_H
 #define __STDIO_CHECKED_H
 
-#pragma CHECKED_SCOPE ON
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE on
 
 #if defined(_WIN32) || defined(_WIN64)
 // stdin, stdout, and stderr only have to be expressions that have
@@ -192,7 +202,7 @@ void perror(const char *s : itype(_Nt_array_ptr<const char>));
 
 #include "_builtin_stdio_checked.h"
 
-#pragma CHECKED_SCOPE OFF
+#pragma CHECKED_SCOPE pop
 
 #endif // guard
 #endif // no C++

--- a/include/stdlib_checked.h
+++ b/include/stdlib_checked.h
@@ -6,15 +6,23 @@
 // specification.                                                      //
 /////////////////////////////////////////////////////////////////////////
 
+#ifndef __cplusplus
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE off
+#endif
 
 #include <stdlib.h>
+
+#ifndef __cplusplus
+#pragma CHECKED_SCOPE pop
+#endif
 
 #ifndef __cplusplus
 #ifndef __STDLIB_CHECKED_H
 #define __STDLIB_CHECKED_H
 
-
-#pragma CHECKED_SCOPE ON
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE on
 
 double atof(const char *s : itype(_Nt_array_ptr<const char>));
 int atoi(const char *s : itype(_Nt_array_ptr<const char>));
@@ -114,7 +122,7 @@ size_t wcstombs(char * restrict output : count(n),
                   itype(restrict _Nt_array_ptr<const wchar_t>),
                 size_t n);
 
-#pragma CHECKED_SCOPE OFF
+#pragma CHECKED_SCOPE pop
 
 #endif  // guard
 #endif  // no c++

--- a/include/string_checked.h
+++ b/include/string_checked.h
@@ -11,14 +11,23 @@
 // TODO: Better Support for _FORTIFY_SOURCE > 0                        //
 /////////////////////////////////////////////////////////////////////////
 
+#ifndef __cplusplus
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE off
+#endif
 
 #include <string.h>
+
+#ifndef __cplusplus
+#pragma CHECKED_SCOPE pop
+#endif
 
 #ifndef __cplusplus
 
 #ifndef __STRING_CHECKED_H
 #define __STRING_CHECKED_H
 
+#pragma CHECKED_SCOPE push
 #pragma CHECKED_SCOPE ON
 
 // GCC has macros that it uses as part of its string implementation to optimize cases
@@ -158,7 +167,7 @@ size_t strlen(const char *s : itype(_Nt_array_ptr<const char>));
 
 #include "_builtin_string_checked.h"
 
-#pragma CHECKED_SCOPE OFF
+#pragma CHECKED_SCOPE pop
 
 #endif // guard
 #endif // no C++

--- a/include/sys/socket_checked.h
+++ b/include/sys/socket_checked.h
@@ -4,12 +4,22 @@
 //                                                                     //
 /////////////////////////////////////////////////////////////////////////
 
+#ifndef __cplusplus
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE off
+#endif
+
 #include <sys/socket.h>
+
+#ifndef __cplusplus
+#pragma CHECKED_SCOPE pop
+#endif
 
 #ifndef __cplusplus
 #ifndef __SOCKET_CHECKED_H
 #define __SOCKET_CHECKED_H
 
+#pragma CHECKED_SCOPE push
 #pragma CHECKED_SCOPE ON
 
 extern int socketpair (int __domain, int __type, int __protocol, 
@@ -114,7 +124,7 @@ extern int accept4 (
     int __flags);
 #endif
 
-#pragma CHECKED_SCOPE OFF
+#pragma CHECKED_SCOPE pop
 
 #endif // guard
 #endif // C++

--- a/include/threads_checked.h
+++ b/include/threads_checked.h
@@ -22,13 +22,23 @@ typedef struct __thread_specific_storage_struct tss_t;
 typedef void (tss_dtor_t)(void *);
 struct timespec;
 #else
+
+#ifndef __cplusplus
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE off
+#endif
 #include <threads.h>
+
+#ifndef __cplusplus
+#pragma CHECKED_SCOPE pop
+#endif
 #endif
 
 #ifndef __cplusplus
 #ifndef __THREADS_CHECKED_H
 #define __THREADS_CHECKED_H
 
+#pragma CHECKED_SCOPE push
 #pragma CHECKED_SCOPE ON
 
 void call_once(once_flag *flag : itype(_Ptr<once_flag>),
@@ -69,7 +79,7 @@ int tss_create(tss_t *key : itype(_Ptr<tss_t>),
 void *tss_get(tss_t key) : itype(_Ptr<void>);
 int tss_set(tss_t key, void *value : itype(_Ptr<void>));
 
-#pragma CHECKED_SCOPE OFF
+#pragma CHECKED_SCOPE pop
 
 #endif // guard
 #endif // no C++

--- a/include/time_checked.h
+++ b/include/time_checked.h
@@ -6,12 +6,22 @@
 // specification.                                                      //
 /////////////////////////////////////////////////////////////////////////
 
+#ifndef __cplusplus
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE off
+#endif
+
 #include <time.h>
+
+#ifndef __cplusplus
+#pragma CHECKED_SCOPE pop
+#endif
 
 #ifndef __cplusplus
 #ifndef __TIME_CHECKED_H
 #define __TIME_CHECKED_H
 
+#pragma CHECKED_SCOPE push
 #pragma CHECKED_SCOPE ON
 
 time_t mktime(struct tm *timeptr : itype(_Ptr<struct tm>));
@@ -37,7 +47,7 @@ size_t strftime(char * restrict output : count(maxsize),
                 const struct tm * restrict timeptr :
                    itype(restrict _Ptr<const struct tm>));
 
-#pragma CHECKED_SCOPE OFF
+#pragma CHECKED_SCOPE pop
 
 #endif
 #endif

--- a/include/unistd_checked.h
+++ b/include/unistd_checked.h
@@ -5,13 +5,23 @@
 // These are POSIX-only                                                //
 /////////////////////////////////////////////////////////////////////////
 
+#ifndef __cplusplus
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE off
+#endif
+
 #include <unistd.h>
+
+#ifndef __cplusplus
+#pragma CHECKED_SCOPE pop
+#endif
 
 #ifndef __cplusplus
 #ifndef __UNISTD_CHECKED_H
 #define __UNISTD_CHECKED_H
 
-#pragma CHECKED_SCOPE ON
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE on
 
 #if _POSIX_VERSION >= 200112L
 
@@ -25,7 +35,7 @@ extern ssize_t write (int __fd, const void *__buf : byte_count(__n), size_t __n)
 
 #endif
 
-#pragma CHECKED_SCOPE OFF
+#pragma CHECKED_SCOPE pop
 
 #endif
 #endif

--- a/tests/typechecking/checked_scope_pragma_bounds_only.c
+++ b/tests/typechecking/checked_scope_pragma_bounds_only.c
@@ -1,0 +1,14 @@
+// Feature tests of typechecking of uses of checked scopes introduced by
+// #pragma CHECKED_SCOPE with the _Bounds_only modifier.
+//
+// This builds the file checked_scope_pragma.c, #defining BOUNDS_ONLY to 1.
+//
+// The following line is for the LLVM test harness:
+//
+// RUN: %clang_cc1 -Wno-unused-value -Wno-pointer-bool-conversion -verify -verify-ignore-unexpected=note -DBOUNDS_ONLY=1 %S/checked_scope_pragma.c
+//
+#import <stdlib.h>
+
+int main(void) {
+  return EXIT_FAILURE;
+}

--- a/tests/typechecking/redeclare_libraries.c
+++ b/tests/typechecking/redeclare_libraries.c
@@ -3,10 +3,23 @@
 //
 // The following lines are for the LLVM test harness:
 //
+// Test include files in an unchecked scope
+//
 // RUN: %clang -fsyntax-only %s
 // RUN: %clang -fsyntax-only -D_FORTIFY_SOURCE=0 %s
 // RUN: %clang -fsyntax-only -D_FORTIFY_SOURCE=1 %s
 // RUN: %clang -fsyntax-only -D_FORTIFY_SOURCE=2 %s
+//
+// Test include files in a checked scope.
+//
+// RUN: %clang -fsyntax-only  -DCHECKED_SCOPE=1 %s
+// RUN: %clang -fsyntax-only -D_FORTIFY_SOURCE=0 -DCHECKED_SCOPE=1 %s
+// RUN: %clang -fsyntax-only -D_FORTIFY_SOURCE=1 -DCHECKED_SCOPE=1 %s
+// RUN: %clang -fsyntax-only -D_FORTIFY_SOURCE=2 -DCHECKED_SCOPE=1 %s
+
+#if CHECKED_SCOPE
+#pragma CHECKED_SCOPE on
+#endif
 
 // C Standard
 #include "../../include/assert_checked.h"


### PR DESCRIPTION
There is new functionality for #pragma CHECKED_SCOPE:
 - Create _Bounds_only checked scopes.  The syntax is
  #pragma CHECKED_SCOPE _Bounds_only.
- Save/restore the checked scope state. The syntax is
  #pragma CHECKED_SCOPE push and #pragma CHECKED_SCOPE pop.
- Allow lower-case on/off directives for CHECKED_SCOPE.

Add tests and use the functionality to improve the checked include files
for the C standard library:
- Add tests for #pragma CHECKED_SCOPE _Bounds_only
- Add tests for #pragma CHECKED_SCOPE push and pop functinality.
- Update #include files to use new push and pop functionality so that
  they can robustly be included in either checked or unchecked scopes.
- Test that #include files can be included in checked scopes.