### PR TITLE
Batch of checked header changes from CCI 2021-05

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -12,12 +12,22 @@ set(files
   assert.h
   errno_checked.h
   errno.h
+  fcntl.h
+  fcntl_checked.h
   fenv_checked.h
   fenv.h
+  grp_checked.h
+  grp.h
   inttypes_checked.h
   inttypes_checked_internal.h
   math_checked.h
   math.h
+  netdb_checked.h
+  netdb.h
+  poll_checked.h
+  poll.h
+  pwd_checked.h
+  pwd.h
   signal_checked.h
   signal.h
   stdchecked.h
@@ -27,8 +37,12 @@ set(files
   stdlib.h
   string_checked.h
   string.h
+  syslog_checked.h
+  syslog.h
   threads_checked.h
   threads.h
+  utime_checked.h
+  utime.h
   time_checked.h
   time.h
   unistd_checked.h
@@ -47,6 +61,8 @@ set(posix_arpa_files
 set(posix_sys_files
   sys/socket_checked.h
   sys/socket.h
+  sys/stat_checked.h
+  sys/stat.h
 )
 
 # Hack - compute the CLANG version from the LLVM version.  The

--- a/include/_builtin_stdio_checked.h
+++ b/include/_builtin_stdio_checked.h
@@ -42,7 +42,7 @@ int __builtin___sprintf_chk(char * restrict buffer : itype(restrict _Nt_array_pt
 #if __has_builtin(__builtin___snprintf_chk) || defined(__GNUC__)
 // snprintf
 extern _Unchecked
-int __snprintf_chk(char * restrict buffer : count(maxlen),
+int __snprintf_chk(char * restrict buffer : itype(restrict _Nt_array_ptr<char>) count(maxlen == 0 ? 0 : maxlen-1),
                    size_t maxlen,
                    int flag,
                    size_t obj_size,
@@ -51,7 +51,7 @@ int __snprintf_chk(char * restrict buffer : count(maxlen),
                    ...);
 
 _Unchecked
-int __builtin___snprintf_chk(char * restrict buffer : count(maxlen),
+int __builtin___snprintf_chk(char * restrict buffer : itype(restrict _Nt_array_ptr<char>) count(maxlen == 0 ? 0 : maxlen-1),
                              size_t maxlen,
                              int flag,
                              size_t obj_size,
@@ -85,7 +85,7 @@ int __builtin___vsprintf_chk(char * restrict buffer : itype(restrict _Nt_array_p
 #if __has_builtin(__builtin___vsnprintf_chk) || defined(__GNUC__)
 // vsnprintf
 extern _Unchecked
-int __vsnprintf_chk(char * restrict buffer : count(maxlen),
+int __vsnprintf_chk(char * restrict buffer : itype(restrict _Nt_array_ptr<char>) count(maxlen == 0 ? 0 : maxlen-1),
                     size_t maxlen,
                     int flag,
                     size_t obj_size,
@@ -94,7 +94,7 @@ int __vsnprintf_chk(char * restrict buffer : count(maxlen),
                     va_list);
 
 _Unchecked
-int __builtin___vsnprintf_chk(char * restrict buffer : count(maxlen),
+int __builtin___vsnprintf_chk(char * restrict buffer : itype(restrict _Nt_array_ptr<char>) count(maxlen == 0 ? 0 : maxlen-1),
                               size_t maxlen,
                               int flag,
                               size_t obj_size,

--- a/include/arpa/inet.h
+++ b/include/arpa/inet.h
@@ -5,11 +5,10 @@
 /////////////////////////////////////////////////////////////////////////
 
 
-#if !defined __checkedc || defined NO_IMPLICIT_INCLUDE_CHECKED_HDRS
-
 // The Windows environment may not have arpa/inet.h
-#if defined __has_include_next
-#if __has_include_next(<arpa/inet.h>)
+#if defined __has_include_next && __has_include_next(<arpa/inet.h>)
+
+#if !defined __checkedc || defined NO_IMPLICIT_INCLUDE_CHECKED_HDRS
 
 #ifdef __checkedc
 #pragma CHECKED_SCOPE push
@@ -22,9 +21,10 @@
 #pragma CHECKED_SCOPE pop
 #endif
 
-#endif // has inet.h
-#endif // defined __has_include_next
-
 #else // checkedc && implicit include enabled
 #include <arpa/inet_checked.h>
+#endif
+
+#else // doesn't have arpa/inet.h
+#error "cannot include 'arpa/inet.h' because this system does not have the original header, even though Checked C provides a wrapper for it"
 #endif

--- a/include/arpa/inet_checked.h
+++ b/include/arpa/inet_checked.h
@@ -6,8 +6,7 @@
 /////////////////////////////////////////////////////////////////////////
 
 // The Windows environment may not have arpa/inet.h
-#if defined __has_include_next
-#if __has_include_next(<arpa/inet.h>)
+#if defined __has_include_next && __has_include_next(<arpa/inet.h>)
 
 #ifdef __checkedc
 #pragma CHECKED_SCOPE push
@@ -35,5 +34,6 @@ extern in_addr_t inet_addr (const char *__cp : itype(_Nt_array_ptr<const char>))
 #endif // guard
 #endif // Checked C
 
-#endif // has inet.h
-#endif // defined __has_include_next
+#else // doesn't have arpa/inet.h
+#error "cannot include 'arpa/inet_checked.h' because this system does not have the original 'arpa/inet.h'"
+#endif

--- a/include/arpa/inet_checked.h
+++ b/include/arpa/inet_checked.h
@@ -27,7 +27,18 @@
 #pragma CHECKED_SCOPE on
 
 extern in_addr_t inet_addr (const char *__cp : itype(_Nt_array_ptr<const char>)) __THROW;
+extern int inet_aton(const char *cp : itype(_Nt_array_ptr<const char>),
+                     struct in_addr *inp : itype(_Ptr<struct in_addr>));
 
+extern char *inet_ntoa(struct in_addr) : itype(_Nt_array_ptr<char>);
+_Unchecked
+extern const char *inet_ntop(int af, const void *restrict src,
+                             char *restrict : itype(restrict _Array_ptr<char>) byte_count(size),
+                             socklen_t size) : itype(_Nt_array_ptr<const char>);
+_Unchecked
+extern int inet_pton(int af,
+                     const char *restrict src : itype(restrict _Nt_array_ptr<const char>),
+                     void *restrict dst);
 
 #pragma CHECKED_SCOPE pop
 

--- a/include/fcntl.h
+++ b/include/fcntl.h
@@ -1,0 +1,23 @@
+//---------------------------------------------------------------------//
+// Wrapper header file that excludes Checked-C-specific declarations   //
+// if the compilation is not for Checked C, or if is for Checked C     //
+// but the implicit inclusion of checked header files is disabled.     //
+/////////////////////////////////////////////////////////////////////////
+
+
+#if !defined __checkedc || defined NO_IMPLICIT_INCLUDE_CHECKED_HDRS
+
+#ifdef __checkedc
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE off
+#endif
+
+#include_next <fcntl.h>
+
+#ifdef __checkedc
+#pragma CHECKED_SCOPE pop
+#endif
+
+#else // checkedc && implicit include enabled
+#include <fcntl_checked.h>
+#endif

--- a/include/fcntl_checked.h
+++ b/include/fcntl_checked.h
@@ -1,0 +1,31 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for some functions in fcntl.h that           //
+// take pointer arguments.                                             //
+//                                                                     //
+/////////////////////////////////////////////////////////////////////////
+
+#ifdef __checkedc
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE off
+#endif
+
+#include_next <fcntl.h>
+
+#ifdef __checkedc
+#pragma CHECKED_SCOPE pop
+#endif
+
+#ifdef __checkedc
+#ifndef __FCNTL_CHECKED_H
+#define __FCNTL_CHECKED_H
+
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE on
+
+_Unchecked
+int open(const char *pathname : itype(_Nt_array_ptr<const char>), int flags, ...);
+
+#pragma CHECKED_SCOPE pop
+
+#endif // guard
+#endif // Checked C

--- a/include/grp.h
+++ b/include/grp.h
@@ -1,0 +1,30 @@
+//---------------------------------------------------------------------//
+// Wrapper header file that excludes Checked-C-specific declarations   //
+// if the compilation is not for Checked C, or if is for Checked C     //
+// but the implicit inclusion of checked header files is disabled.     //
+/////////////////////////////////////////////////////////////////////////
+
+
+// The Windows environment may not have grp.h
+#if defined __has_include_next && __has_include_next(<grp.h>)
+
+#if !defined __checkedc || defined NO_IMPLICIT_INCLUDE_CHECKED_HDRS
+
+#ifdef __checkedc
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE off
+#endif
+
+#include_next <grp.h>
+
+#ifdef __checkedc
+#pragma CHECKED_SCOPE pop
+#endif
+
+#else // checkedc && implicit include enabled
+#include <grp_checked.h>
+#endif
+
+#else // doesn't have grp.h
+#error "cannot include 'grp.h' because this system does not have the original header, even though Checked C provides a wrapper for it"
+#endif

--- a/include/grp_checked.h
+++ b/include/grp_checked.h
@@ -1,0 +1,37 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for functions in grp.h that                  //
+// take pointer arguments.                                             //
+//                                                                     //
+/////////////////////////////////////////////////////////////////////////
+
+// The Windows environment may not have grp.h
+#if defined __has_include_next && __has_include_next(<grp.h>)
+
+#ifdef __checkedc
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE off
+#endif
+
+#include_next <grp.h>
+
+#ifdef __checkedc
+#pragma CHECKED_SCOPE pop
+#endif
+
+#ifdef __checkedc
+#ifndef __GRP_CHECKED_H
+#define __GRP_CHECKED_H
+
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE on
+
+int initgroups(const char *user : itype(_Nt_array_ptr<const char>), gid_t group);
+
+#pragma CHECKED_SCOPE pop
+
+#endif // guard
+#endif // Checked C
+
+#else // doesn't have grp.h
+#error "cannot include 'grp_checked.h' because this system does not have the original 'grp.h'"
+#endif

--- a/include/netdb.h
+++ b/include/netdb.h
@@ -1,0 +1,30 @@
+//---------------------------------------------------------------------//
+// Wrapper header file that excludes Checked-C-specific declarations   //
+// if the compilation is not for Checked C, or if is for Checked C     //
+// but the implicit inclusion of checked header files is disabled.     //
+/////////////////////////////////////////////////////////////////////////
+
+
+// The Windows environment may not have netdb.h
+#if defined __has_include_next && __has_include_next(<netdb.h>)
+
+#if !defined __checkedc || defined NO_IMPLICIT_INCLUDE_CHECKED_HDRS
+
+#ifdef __checkedc
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE off
+#endif
+
+#include_next <netdb.h>
+
+#ifdef __checkedc
+#pragma CHECKED_SCOPE pop
+#endif
+
+#else // checkedc && implicit include enabled
+#include <netdb_checked.h>
+#endif
+
+#else // doesn't have netdb.h
+#error "cannot include 'netdb.h' because this system does not have the original header, even though Checked C provides a wrapper for it"
+#endif

--- a/include/netdb_checked.h
+++ b/include/netdb_checked.h
@@ -1,0 +1,45 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for functions in netdb.h that                //
+// take pointer arguments.                                             //
+//                                                                     //
+/////////////////////////////////////////////////////////////////////////
+
+// The Windows environment may not have netdb.h
+#if defined __has_include_next && __has_include_next(<netdb.h>)
+
+#ifdef __checkedc
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE off
+#endif
+
+#include_next <netdb.h>
+
+#ifdef __checkedc
+#pragma CHECKED_SCOPE pop
+#endif
+
+#ifdef __checkedc
+#ifndef __NETDB_CHECKED_H
+#define __NETDB_CHECKED_H
+
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE on
+
+extern struct hostent *gethostbyname(const char *name : itype(_Nt_array_ptr<const char>)) : itype(_Ptr<struct hostent>);
+_Unchecked
+extern struct hostent *gethostbyaddr(const void *addr : byte_count(len), socklen_t len, int type);
+
+int getaddrinfo(const char *node : itype(_Nt_array_ptr<const char>) , const char *service : itype(_Nt_array_ptr<const char>),
+                const struct addrinfo *hints : itype(_Ptr<const struct addrinfo>),
+                struct addrinfo **res : itype(_Nt_array_ptr<_Ptr<struct addrinfo>>));
+void freeaddrinfo(struct addrinfo *res : itype(_Ptr<struct addrinfo>));
+const char *gai_strerror(int errcode) : itype(_Nt_array_ptr<const char>);
+
+#pragma CHECKED_SCOPE pop
+
+#endif // guard
+#endif // Checked C
+
+#else // doesn't have netdb.h
+#error "cannot include 'netdb_checked.h' because this system does not have the original 'netdb.h'"
+#endif

--- a/include/poll.h
+++ b/include/poll.h
@@ -1,0 +1,30 @@
+//---------------------------------------------------------------------//
+// Wrapper header file that excludes Checked-C-specific declarations   //
+// if the compilation is not for Checked C, or if is for Checked C     //
+// but the implicit inclusion of checked header files is disabled.     //
+/////////////////////////////////////////////////////////////////////////
+
+
+// The Windows environment may not have poll.h
+#if defined __has_include_next && __has_include_next(<poll.h>)
+
+#if !defined __checkedc || defined NO_IMPLICIT_INCLUDE_CHECKED_HDRS
+
+#ifdef __checkedc
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE off
+#endif
+
+#include_next <poll.h>
+
+#ifdef __checkedc
+#pragma CHECKED_SCOPE pop
+#endif
+
+#else // checkedc && implicit include enabled
+#include <poll_checked.h>
+#endif
+
+#else // doesn't have poll.h
+#error "cannot include 'poll.h' because this system does not have the original header, even though Checked C provides a wrapper for it"
+#endif

--- a/include/poll_checked.h
+++ b/include/poll_checked.h
@@ -1,0 +1,37 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for functions in poll.h that                 //
+// take pointer arguments.                                             //
+//                                                                     //
+/////////////////////////////////////////////////////////////////////////
+
+// The Windows environment may not have poll.h
+#if defined __has_include_next && __has_include_next(<poll.h>)
+
+#ifdef __checkedc
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE off
+#endif
+
+#include_next <poll.h>
+
+#ifdef __checkedc
+#pragma CHECKED_SCOPE pop
+#endif
+
+#ifdef __checkedc
+#ifndef __POLL_CHECKED_H
+#define __POLL_CHECKED_H
+
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE on
+
+extern int poll(struct pollfd fds[] : count(nfds), nfds_t nfds, int timeout);
+
+#pragma CHECKED_SCOPE pop
+
+#endif // guard
+#endif // Checked C
+
+#else // doesn't have poll.h
+#error "cannot include 'poll_checked.h' because this system does not have the original 'poll.h'"
+#endif

--- a/include/pwd.h
+++ b/include/pwd.h
@@ -1,0 +1,30 @@
+//---------------------------------------------------------------------//
+// Wrapper header file that excludes Checked-C-specific declarations   //
+// if the compilation is not for Checked C, or if is for Checked C     //
+// but the implicit inclusion of checked header files is disabled.     //
+/////////////////////////////////////////////////////////////////////////
+
+
+// The Windows environment may not have pwd.h
+#if defined __has_include_next && __has_include_next(<pwd.h>)
+
+#if !defined __checkedc || defined NO_IMPLICIT_INCLUDE_CHECKED_HDRS
+
+#ifdef __checkedc
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE off
+#endif
+
+#include_next <pwd.h>
+
+#ifdef __checkedc
+#pragma CHECKED_SCOPE pop
+#endif
+
+#else // checkedc && implicit include enabled
+#include <pwd_checked.h>
+#endif
+
+#else // doesn't have pwd.h
+#error "cannot include 'pwd.h' because this system does not have the original header, even though Checked C provides a wrapper for it"
+#endif

--- a/include/pwd_checked.h
+++ b/include/pwd_checked.h
@@ -1,0 +1,49 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for functions in pwd.h that                  //
+// take pointer arguments.                                             //
+//                                                                     //
+/////////////////////////////////////////////////////////////////////////
+
+// The Windows environment may not have pwd.h
+#if defined __has_include_next && __has_include_next(<pwd.h>)
+
+#ifdef __checkedc
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE off
+#endif
+
+#include_next <pwd.h>
+
+#ifdef __checkedc
+#pragma CHECKED_SCOPE pop
+#endif
+
+#ifdef __checkedc
+#ifndef __PWD_CHECKED_H
+#define __PWD_CHECKED_H
+
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE on
+
+struct passwd *getpwnam(const char *user : itype(_Nt_array_ptr<const char>)) : itype(_Ptr<struct passwd>);
+_Unchecked
+int getpwnam_r(const char *user : itype(_Nt_array_ptr<const char>),
+               struct passwd *pwd : itype(_Ptr<struct passwd>),
+               char *buf : byte_count(bufsize),
+               size_t bufsize, struct passwd **result : itype(_Ptr<_Ptr<struct passwd>>));
+
+struct passwd *getpwuid(uid_t uid) : itype(_Ptr<struct passwd>);
+_Unchecked
+int            getpwuid_r(uid_t uid,
+               struct passwd *pwd : itype(_Ptr<struct passwd>),
+               char *buf : byte_count(bufsize),
+               size_t bufsize, struct passwd **result : itype(_Ptr<_Ptr<struct passwd>>));
+
+#pragma CHECKED_SCOPE pop
+
+#endif // guard
+#endif // Checked C
+
+#else // doesn't have pwd.h
+#error "cannot include 'pwd_checked.h' because this system does not have the original 'pwd.h'"
+#endif

--- a/include/stdio_checked.h
+++ b/include/stdio_checked.h
@@ -46,6 +46,7 @@ int fclose(FILE *stream : itype(_Ptr<FILE>));
 int fflush(FILE *stream : itype(_Ptr<FILE>));
 FILE *fopen(const char * restrict filename : itype(restrict _Nt_array_ptr<const char>),
             const char * restrict mode : itype(restrict _Nt_array_ptr<const char>)) : itype(_Ptr<FILE>);
+FILE *fdopen(int fd, const char *mode : itype(_Nt_array_ptr<const char>)) : itype(_Ptr<FILE>);
 FILE *freopen(const char * restrict filename : itype(restrict _Nt_array_ptr<const char>),
               const char * restrict mode : itype(restrict _Nt_array_ptr<const char>),
               FILE * restrict stream : itype(restrict _Ptr<FILE>)) :
@@ -200,6 +201,8 @@ void clearerr(FILE *stream : itype(_Ptr<FILE>));
 int feof(FILE *stream : itype(_Ptr<FILE>));
 int ferror(FILE *stream : itype(_Ptr<FILE>));
 void perror(const char *s : itype(_Nt_array_ptr<const char>));
+
+int fileno (FILE *stream : itype(_Ptr<FILE>));
 
 #include "_builtin_stdio_checked.h"
 

--- a/include/stdio_checked.h
+++ b/include/stdio_checked.h
@@ -146,8 +146,9 @@ int vscanf(const char * restrict format : itype(restrict _Nt_array_ptr<const cha
 #if _FORTIFY_SOURCE == 0 || !defined(vsnprintf)
 #undef vsnprintf
 _Unchecked
-int vsnprintf(char * restrict s : count(n), size_t n,
-              const char * restrict format,
+int vsnprintf(char * restrict s : itype(restrict _Nt_array_ptr<char>) count(n == 0 ? 0 : n-1),
+              size_t n,
+              const char * restrict format : itype(restrict _Nt_array_ptr<const char>),
               va_list arg);
 #endif
 

--- a/include/stdlib_checked.h
+++ b/include/stdlib_checked.h
@@ -74,7 +74,7 @@ void *aligned_alloc(size_t alignment, size_t size) : byte_count(size);
 _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
 _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
 _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
-_Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+_Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(0), size_t size) : itype(_Array_ptr<T>) byte_count(size);
 
 char *getenv(const char *n : itype(_Nt_array_ptr<const char>)) : itype(_Nt_array_ptr<char>);
 

--- a/include/stdlib_checked.h
+++ b/include/stdlib_checked.h
@@ -77,6 +77,7 @@ _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(si
 _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(0), size_t size) : itype(_Array_ptr<T>) byte_count(size);
 
 char *getenv(const char *n : itype(_Nt_array_ptr<const char>)) : itype(_Nt_array_ptr<char>);
+int putenv(char *string : itype(_Nt_array_ptr<char>));
 
 int atexit(void ((*func)(void)) : itype(_Ptr<void (void)>));
 int atquick_exit(void ((*func)(void)) : itype(_Ptr<void (void)>));

--- a/include/string_checked.h
+++ b/include/string_checked.h
@@ -121,6 +121,8 @@ int memcmp(const void *src1 : byte_count(n), const void *src2 : byte_count(n),
 
 int strcmp(const char *src1 : itype(_Nt_array_ptr<const char>),
            const char *src2 : itype(_Nt_array_ptr<const char>));
+int strcasecmp(const char *src1 : itype(_Nt_array_ptr<const char>),
+               const char *src2 : itype(_Nt_array_ptr<const char>));
 int strcoll(const char *src1 : itype(_Nt_array_ptr<const char>),
             const char *src2 : itype(_Nt_array_ptr<const  char>));
 
@@ -134,6 +136,9 @@ int strcoll(const char *src1 : itype(_Nt_array_ptr<const char>),
 int strncmp(const char *src : itype(_Nt_array_ptr<const char>),
             const char *s2 : itype(_Nt_array_ptr<const char>),
             size_t n);
+int strncasecmp(const char *src : itype(_Nt_array_ptr<const char>),
+                const char *s2 : itype(_Nt_array_ptr<const char>),
+                size_t n);
 
 size_t strxfrm(char * restrict dest : count(n),
                const char * restrict src :

--- a/include/sys/socket.h
+++ b/include/sys/socket.h
@@ -5,11 +5,10 @@
 /////////////////////////////////////////////////////////////////////////
 
 
-#if !defined __checkedc || defined NO_IMPLICIT_INCLUDE_CHECKED_HDRS
-
 // The Windows environment may not have sys/socket.h
-#if defined __has_include_next
-#if __has_include_next(<sys/socket.h>)
+#if defined __has_include_next && __has_include_next(<sys/socket.h>)
+
+#if !defined __checkedc || defined NO_IMPLICIT_INCLUDE_CHECKED_HDRS
 
 #ifdef __checkedc
 #pragma CHECKED_SCOPE push
@@ -22,9 +21,10 @@
 #pragma CHECKED_SCOPE pop
 #endif
 
-#endif // has socket.h
-#endif // defined __has_include_next
-
 #else // checkedc && implicit include enabled
 #include <sys/socket_checked.h>
+#endif
+
+#else // doesn't have sys/socket.h
+#error "cannot include 'sys/socket.h' because this system does not have the original header, even though Checked C provides a wrapper for it"
 #endif

--- a/include/sys/socket_checked.h
+++ b/include/sys/socket_checked.h
@@ -5,8 +5,7 @@
 /////////////////////////////////////////////////////////////////////////
 
 // The Windows environment may not have sys/socket.h
-#if defined __has_include_next
-#if __has_include_next(<sys/socket.h>)
+#if defined __has_include_next && __has_include_next(<sys/socket.h>)
 
 #ifdef __checkedc
 #pragma CHECKED_SCOPE push
@@ -140,5 +139,6 @@ extern int accept4 (
 #endif // guard
 #endif // Checked C
 
-#endif // has socket.h
-#endif // defined __has_include_next
+#else // doesn't have sys/socket.h
+#error "cannot include 'sys/socket_checked.h' because this system does not have the original 'sys/socket.h'"
+#endif

--- a/include/sys/stat.h
+++ b/include/sys/stat.h
@@ -1,0 +1,23 @@
+//---------------------------------------------------------------------//
+// Wrapper header file that excludes Checked-C-specific declarations   //
+// if the compilation is not for Checked C, or if is for Checked C     //
+// but the implicit inclusion of checked header files is disabled.     //
+/////////////////////////////////////////////////////////////////////////
+
+
+#if !defined __checkedc || defined NO_IMPLICIT_INCLUDE_CHECKED_HDRS
+
+#ifdef __checkedc
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE off
+#endif
+
+#include_next <sys/stat.h>
+
+#ifdef __checkedc
+#pragma CHECKED_SCOPE pop
+#endif
+
+#else // checkedc && implicit include enabled
+#include <sys/stat_checked.h>
+#endif

--- a/include/sys/stat_checked.h
+++ b/include/sys/stat_checked.h
@@ -1,0 +1,38 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for functions in sys/stat.h that             //
+// take pointer arguments.                                             //
+//                                                                     //
+/////////////////////////////////////////////////////////////////////////
+
+#ifdef __checkedc
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE off
+#endif
+
+#include_next <sys/stat.h>
+
+#ifdef __checkedc
+#pragma CHECKED_SCOPE pop
+#endif
+
+#ifdef __checkedc
+#ifndef __STAT_CHECKED_H
+#define __STAT_CHECKED_H
+
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE on
+
+extern int mkdir(const char *pathname : itype(_Nt_array_ptr<const char>), mode_t mode);
+extern int chmod(const char *pathname : itype(_Nt_array_ptr<const char>), mode_t mode);
+extern int fstat(int fd, struct stat *buf : itype(_Ptr<struct stat>));
+extern int lstat(const char *restrict file : itype(restrict _Nt_array_ptr<const char>),
+                 struct stat *restrict buf : itype(restrict _Ptr<struct stat>));
+extern int stat(const char *restrict file : itype(restrict _Nt_array_ptr<const char>),
+                struct stat *restrict buf : itype(restrict _Ptr<struct stat>));
+
+// int fchmod(int, mode_t) and mode_t umask(mode_t) inherited from system header
+
+#pragma CHECKED_SCOPE pop
+
+#endif // guard
+#endif // Checked C

--- a/include/syslog.h
+++ b/include/syslog.h
@@ -1,0 +1,30 @@
+//---------------------------------------------------------------------//
+// Wrapper header file that excludes Checked-C-specific declarations   //
+// if the compilation is not for Checked C, or if is for Checked C     //
+// but the implicit inclusion of checked header files is disabled.     //
+/////////////////////////////////////////////////////////////////////////
+
+
+// The Windows environment may not have syslog.h
+#if defined __has_include_next && __has_include_next(<syslog.h>)
+
+#if !defined __checkedc || defined NO_IMPLICIT_INCLUDE_CHECKED_HDRS
+
+#ifdef __checkedc
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE off
+#endif
+
+#include_next <syslog.h>
+
+#ifdef __checkedc
+#pragma CHECKED_SCOPE pop
+#endif
+
+#else // checkedc && implicit include enabled
+#include <syslog_checked.h>
+#endif
+
+#else // doesn't have syslog.h
+#error "cannot include 'syslog.h' because this system does not have the original header, even though Checked C provides a wrapper for it"
+#endif

--- a/include/syslog_checked.h
+++ b/include/syslog_checked.h
@@ -1,0 +1,59 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for functions in syslog.h that               //
+// take pointer arguments.                                             //
+//                                                                     //
+/////////////////////////////////////////////////////////////////////////
+
+// The Windows environment may not have syslog.h
+#if defined __has_include_next && __has_include_next(<syslog.h>)
+
+#ifdef __checkedc
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE off
+#endif
+
+#include_next <syslog.h>
+
+#ifdef __checkedc
+#pragma CHECKED_SCOPE pop
+#endif
+
+#ifdef __checkedc
+#ifndef __SYSLOG_CHECKED_H
+#define __SYSLOG_CHECKED_H
+
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE on
+
+// TODO: printing and scanning functions are still mostly
+// unchecked because of the use of varargs.
+// * There may not be enough arguments for the format string.
+// * Any pointer arguments may not meet the requirements of the
+//  format string.
+
+void closelog(void);
+void openlog (const char *__ident : itype(_Nt_array_ptr<const char>), int __option, int __facility);
+
+// TODO: Is this condition right? I don't see any precedent in the Checked C
+// system headers for __foo_chk without __builtin___foo_chk.
+#if _FORTIFY_SOURCE == 0 || !defined(syslog)
+#undef syslog
+_Unchecked
+void syslog(int priority, const char * format : itype(_Nt_array_ptr<const char>), ...);
+#else
+_Unchecked
+void __syslog_chk(int priority, int flag, const char * format : itype(_Nt_array_ptr<const char>), ...);
+#endif
+
+/* TODO: Not sure how to get va_list included; stdio_checked.h might be the example to look at */
+/* _Unchecked */
+/* void vsyslog (int __pri, const char *__fmt  : itype(_Nt_array_ptr<const char>), va_list arg); */
+
+#pragma CHECKED_SCOPE pop
+
+#endif // guard
+#endif // Checked C
+
+#else // doesn't have syslog.h
+#error "cannot include 'syslog_checked.h' because this system does not have the original 'syslog.h'"
+#endif

--- a/include/threads.h
+++ b/include/threads.h
@@ -5,12 +5,11 @@
 /////////////////////////////////////////////////////////////////////////
 
 
-#if !defined __checkedc || defined NO_IMPLICIT_INCLUDE_CHECKED_HDRS
-
 // C implementations may not support the C11 threads package or even the
 // macro that says C11 threads are not supported.
-#if defined __has_include_next
-#if __has_include_next(<threads.h>)
+#if defined __has_include_next && __has_include_next(<threads.h>)
+
+#if !defined __checkedc || defined NO_IMPLICIT_INCLUDE_CHECKED_HDRS
 
 #ifdef __checkedc
 #pragma CHECKED_SCOPE push
@@ -23,9 +22,10 @@
 #pragma CHECKED_SCOPE pop
 #endif
 
-#endif // has threads.h
-#endif // defined __has_include_next
-
 #else // checkedc && implicit include enabled
 #include <threads_checked.h>
+#endif
+
+#else // doesn't have threads.h
+#error "cannot include 'threads.h' because this system does not have the original header, even though Checked C provides a wrapper for it"
 #endif

--- a/include/threads_checked.h
+++ b/include/threads_checked.h
@@ -23,8 +23,7 @@ typedef void (tss_dtor_t)(void *);
 struct timespec;
 #else
 
-#if defined __has_include_next
-#if __has_include_next(<threads.h>)
+#if defined __has_include_next && __has_include_next(<threads.h>)
 
 #ifdef __checkedc
 #pragma CHECKED_SCOPE push
@@ -37,8 +36,9 @@ struct timespec;
 #pragma CHECKED_SCOPE pop
 #endif
 
-#endif // has threads.h
-#endif // defined __has_include_next
+#else // doesn't have threads.h
+#error "cannot include 'threads_checked.h' because this system does not have the original 'threads.h'"
+#endif // threads.h
 #endif // _CHECKEDC_MOCKUP_THREADS
 
 

--- a/include/time_checked.h
+++ b/include/time_checked.h
@@ -41,7 +41,7 @@ struct tm *gmtime(const time_t *timer : itype(_Ptr<const time_t>)) :
 struct tm *localtime(const time_t *timer : itype(_Ptr<const time_t>)) :
   itype(_Ptr<struct tm>);
 
-size_t strftime(char * restrict output : count(maxsize),
+size_t strftime(char * restrict output : itype(restrict _Nt_array_ptr<char>) count(maxsize),
                 size_t maxsize,
                 const char * restrict format : itype(restrict _Nt_array_ptr<const char>),
                 const struct tm * restrict timeptr :

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -5,13 +5,12 @@
 /////////////////////////////////////////////////////////////////////////
 
 
-#if !defined __checkedc || defined NO_IMPLICIT_INCLUDE_CHECKED_HDRS
-
 // Uses clang-specific __has_include macro to detect unistd.h
 // which is required by Posix Standard.
 // The Windows environment also may not have unistd.h
-#if defined __has_include_next
-#if __has_include_next(<unistd.h>)
+#if defined __has_include_next && __has_include_next(<unistd.h>)
+
+#if !defined __checkedc || defined NO_IMPLICIT_INCLUDE_CHECKED_HDRS
 
 #ifdef __checkedc
 #pragma CHECKED_SCOPE push
@@ -24,9 +23,10 @@
 #pragma CHECKED_SCOPE pop
 #endif
 
-#endif // has unistd.h
-#endif // defined __has_include_next
-
 #else // checkedc && implicit include enabled
 #include <unistd_checked.h>
+#endif
+
+#else // doesn't have unistd.h
+#error "cannot include 'unistd.h' because this system does not have the original header, even though Checked C provides a wrapper for it"
 #endif

--- a/include/unistd_checked.h
+++ b/include/unistd_checked.h
@@ -31,7 +31,21 @@
 
 #if _POSIX_VERSION >= 200112L
 
+char *getpass(const char *prompt : itype(_Nt_array_ptr<const char>)) : itype(_Nt_array_ptr<char>);
+char *crypt(const char *phrase : itype(_Nt_array_ptr<const char>), const char *setting : itype(_Nt_array_ptr<const char>)) : itype(_Nt_array_ptr<char>);
+
 extern char ** environ : itype(_Nt_array_ptr<_Nt_array_ptr<char>>);
+
+extern char *getcwd(char *buf : itype(_Nt_array_ptr<char>), size_t size) : itype(_Nt_array_ptr<char>);
+extern char *getwd(char *buf : itype(_Nt_array_ptr<char>)) : itype(_Nt_array_ptr<char>);
+extern char *get_current_dir_name(void) : itype(_Nt_array_ptr<char>);
+extern int rmdir(const char *pathname : itype(_Nt_array_ptr<const char>));
+extern int chdir(const char *p_dirname : itype(_Nt_array_ptr<const char>));
+extern ssize_t readlink (const char *restrict path : itype(restrict _Nt_array_ptr<const char>),
+                         char *restrict buf : itype(restrict _Nt_array_ptr<char>), size_t len);
+extern int chroot(const char *dirname : itype(_Nt_array_ptr<const char>));
+int unlink(const char *pathname : itype(_Nt_array_ptr<const char>));
+int mkstemp(char *template : itype(_Nt_array_ptr<char>));
 
 #ifdef __APPLE__
 
@@ -46,6 +60,13 @@ extern ssize_t read (int __fd, void *__buf : byte_count(__nbytes), size_t __nbyt
 extern ssize_t write (int __fd, const void *__buf : byte_count(__n), size_t __n) __wur;
 
 #endif
+
+extern int execve(const char *pathname : itype(_Nt_array_ptr<const char>),
+                  char * const *argv : itype(_Nt_array_ptr<const _Nt_array_ptr<char>>),
+                  char * const *envp : itype(_Nt_array_ptr<const _Nt_array_ptr<char>>));
+
+int gethostname(char *name : count(len), size_t len);
+
 #endif
 
 #pragma CHECKED_SCOPE pop

--- a/include/unistd_checked.h
+++ b/include/unistd_checked.h
@@ -9,8 +9,7 @@
 // Uses clang-specific __has_include macro to detect unistd.h
 // which is required by Posix Standard.
 // The Windows environment also may not have unistd.h
-#if defined __has_include_next
-#if __has_include_next(<unistd.h>)
+#if defined __has_include_next && __has_include_next(<unistd.h>)
 
 #ifdef __checkedc
 #pragma CHECKED_SCOPE push
@@ -54,5 +53,6 @@ extern ssize_t write (int __fd, const void *__buf : byte_count(__n), size_t __n)
 #endif // guard
 #endif // Checked C
 
-#endif // has unistd.h
-#endif // defined __has_include_next
+#else // doesn't have unistd.h
+#error "cannot include 'unistd_checked.h' because this system does not have the original 'unistd.h'"
+#endif

--- a/include/utime.h
+++ b/include/utime.h
@@ -1,0 +1,30 @@
+//---------------------------------------------------------------------//
+// Wrapper header file that excludes Checked-C-specific declarations   //
+// if the compilation is not for Checked C, or if is for Checked C     //
+// but the implicit inclusion of checked header files is disabled.     //
+/////////////////////////////////////////////////////////////////////////
+
+
+// The Windows environment may not have utime.h
+#if defined __has_include_next && __has_include_next(<utime.h>)
+
+#if !defined __checkedc || defined NO_IMPLICIT_INCLUDE_CHECKED_HDRS
+
+#ifdef __checkedc
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE off
+#endif
+
+#include_next <utime.h>
+
+#ifdef __checkedc
+#pragma CHECKED_SCOPE pop
+#endif
+
+#else // checkedc && implicit include enabled
+#include <utime_checked.h>
+#endif
+
+#else // doesn't have utime.h
+#error "cannot include 'utime.h' because this system does not have the original header, even though Checked C provides a wrapper for it"
+#endif

--- a/include/utime_checked.h
+++ b/include/utime_checked.h
@@ -1,0 +1,38 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for functions in utime.h that                //
+// take pointer arguments.                                             //
+//                                                                     //
+/////////////////////////////////////////////////////////////////////////
+
+// The Windows environment may not have utime.h
+#if defined __has_include_next && __has_include_next(<utime.h>)
+
+#ifdef __checkedc
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE off
+#endif
+
+#include_next <utime.h>
+
+#ifdef __checkedc
+#pragma CHECKED_SCOPE pop
+#endif
+
+#ifdef __checkedc
+#ifndef __UTIME_CHECKED_H
+#define __UTIME_CHECKED_H
+
+#pragma CHECKED_SCOPE push
+#pragma CHECKED_SCOPE on
+
+extern int utime (const char *file : itype(_Nt_array_ptr<const char>),
+                  const struct utimbuf *file_times : itype(_Ptr<const struct utimbuf>));
+
+#pragma CHECKED_SCOPE pop
+
+#endif // guard
+#endif // Checked C
+
+#else // doesn't have utime.h
+#error "cannot include 'utime_checked.h' because this system does not have the original 'utime.h'"
+#endif

--- a/tests/checked_headers/redeclare_libs_explicit.c
+++ b/tests/checked_headers/redeclare_libs_explicit.c
@@ -110,11 +110,3 @@
 // CHECK_ENABLED: #pragma CHECKED_SCOPE on
 // CHECK_DISABLED: checkedc_extensions.h
 // CHECK_DISABLED-NOT: #pragma CHECKED_SCOPE on
-
-
-
-// Posix Headers
-// These header files may or may not be present in all environments.
-#include <unistd_checked.h>
-#include <sys/socket_checked.h>
-#include <arpa/inet_checked.h>

--- a/tests/checked_headers/redeclare_libs_explicit.c
+++ b/tests/checked_headers/redeclare_libs_explicit.c
@@ -105,6 +105,20 @@
 // CHECK_DISABLED: time_checked.h
 // CHECK_DISABLED-NOT: #pragma CHECKED_SCOPE on
 
+// Headers that are not in the C standard but are still present on Windows
+
+#include <fcntl_checked.h>
+// CHECK_ENABLED: fcntl_checked.h
+// CHECK_ENABLED: #pragma CHECKED_SCOPE on
+// CHECK_DISABLED: fcntl_checked.h
+// CHECK_DISABLED-NOT: #pragma CHECKED_SCOPE on
+
+#include <sys/stat_checked.h>
+// CHECK_ENABLED: stat_checked.h
+// CHECK_ENABLED: #pragma CHECKED_SCOPE on
+// CHECK_DISABLED: stat_checked.h
+// CHECK_DISABLED-NOT: #pragma CHECKED_SCOPE on
+
 #include <checkedc_extensions.h>
 // CHECK_ENABLED: checkedc_extensions.h
 // CHECK_ENABLED: #pragma CHECKED_SCOPE on

--- a/tests/checked_headers/redeclare_libs_explicit_linux.c
+++ b/tests/checked_headers/redeclare_libs_explicit_linux.c
@@ -40,3 +40,39 @@
 // CHECK_ENABLED: #pragma CHECKED_SCOPE on
 // CHECK_DISABLED: inet_checked.h
 // CHECK_DISABLED-NOT: #pragma CHECKED_SCOPE on
+
+#include <grp_checked.h>
+// CHECK_ENABLED: grp_checked.h
+// CHECK_ENABLED: #pragma CHECKED_SCOPE on
+// CHECK_DISABLED: grp_checked.h
+// CHECK_DISABLED-NOT: #pragma CHECKED_SCOPE on
+
+#include <netdb_checked.h>
+// CHECK_ENABLED: netdb_checked.h
+// CHECK_ENABLED: #pragma CHECKED_SCOPE on
+// CHECK_DISABLED: netdb_checked.h
+// CHECK_DISABLED-NOT: #pragma CHECKED_SCOPE on
+
+#include <poll_checked.h>
+// CHECK_ENABLED: poll_checked.h
+// CHECK_ENABLED: #pragma CHECKED_SCOPE on
+// CHECK_DISABLED: poll_checked.h
+// CHECK_DISABLED-NOT: #pragma CHECKED_SCOPE on
+
+#include <pwd_checked.h>
+// CHECK_ENABLED: pwd_checked.h
+// CHECK_ENABLED: #pragma CHECKED_SCOPE on
+// CHECK_DISABLED: pwd_checked.h
+// CHECK_DISABLED-NOT: #pragma CHECKED_SCOPE on
+
+#include <syslog_checked.h>
+// CHECK_ENABLED: syslog_checked.h
+// CHECK_ENABLED: #pragma CHECKED_SCOPE on
+// CHECK_DISABLED: syslog_checked.h
+// CHECK_DISABLED-NOT: #pragma CHECKED_SCOPE on
+
+#include <utime_checked.h>
+// CHECK_ENABLED: utime_checked.h
+// CHECK_ENABLED: #pragma CHECKED_SCOPE on
+// CHECK_DISABLED: utime_checked.h
+// CHECK_DISABLED-NOT: #pragma CHECKED_SCOPE on

--- a/tests/checked_headers/redeclare_libs_implicit.c
+++ b/tests/checked_headers/redeclare_libs_implicit.c
@@ -103,11 +103,3 @@
 // CHECK_ENABLED: #pragma CHECKED_SCOPE on
 // CHECK_DISABLED-NOT: time_checked.h
 // CHECK_DISABLED-NOT: #pragma CHECKED_SCOPE on
-
-
-
-// Posix Headers
-// These header files may or may not be present in all environments.
-#include <unistd.h>
-#include <sys/socket.h>
-#include <arpa/inet.h>

--- a/tests/checked_headers/redeclare_libs_implicit.c
+++ b/tests/checked_headers/redeclare_libs_implicit.c
@@ -103,3 +103,17 @@
 // CHECK_ENABLED: #pragma CHECKED_SCOPE on
 // CHECK_DISABLED-NOT: time_checked.h
 // CHECK_DISABLED-NOT: #pragma CHECKED_SCOPE on
+
+// Headers that are not in the C standard but are still present on Windows
+
+#include <fcntl.h>
+// CHECK_ENABLED: fcntl_checked.h
+// CHECK_ENABLED: #pragma CHECKED_SCOPE on
+// CHECK_DISABLED-NOT: fcntl_checked.h
+// CHECK_DISABLED-NOT: #pragma CHECKED_SCOPE on
+
+#include <sys/stat.h>
+// CHECK_ENABLED: stat_checked.h
+// CHECK_ENABLED: #pragma CHECKED_SCOPE on
+// CHECK_DISABLED-NOT: stat_checked.h
+// CHECK_DISABLED-NOT: #pragma CHECKED_SCOPE on

--- a/tests/checked_headers/redeclare_libs_implicit_linux.c
+++ b/tests/checked_headers/redeclare_libs_implicit_linux.c
@@ -34,3 +34,39 @@
 // CHECK_ENABLED: #pragma CHECKED_SCOPE on
 // CHECK_DISABLED-NOT: inet_checked.h
 // CHECK_DISABLED-NOT: #pragma CHECKED_SCOPE on
+
+#include <grp.h>
+// CHECK_ENABLED: grp_checked.h
+// CHECK_ENABLED: #pragma CHECKED_SCOPE on
+// CHECK_DISABLED-NOT: grp_checked.h
+// CHECK_DISABLED-NOT: #pragma CHECKED_SCOPE on
+
+#include <netdb.h>
+// CHECK_ENABLED: netdb_checked.h
+// CHECK_ENABLED: #pragma CHECKED_SCOPE on
+// CHECK_DISABLED-NOT: netdb_checked.h
+// CHECK_DISABLED-NOT: #pragma CHECKED_SCOPE on
+
+#include <poll.h>
+// CHECK_ENABLED: poll_checked.h
+// CHECK_ENABLED: #pragma CHECKED_SCOPE on
+// CHECK_DISABLED-NOT: poll_checked.h
+// CHECK_DISABLED-NOT: #pragma CHECKED_SCOPE on
+
+#include <pwd.h>
+// CHECK_ENABLED: pwd_checked.h
+// CHECK_ENABLED: #pragma CHECKED_SCOPE on
+// CHECK_DISABLED-NOT: pwd_checked.h
+// CHECK_DISABLED-NOT: #pragma CHECKED_SCOPE on
+
+#include <syslog.h>
+// CHECK_ENABLED: syslog_checked.h
+// CHECK_ENABLED: #pragma CHECKED_SCOPE on
+// CHECK_DISABLED-NOT: syslog_checked.h
+// CHECK_DISABLED-NOT: #pragma CHECKED_SCOPE on
+
+#include <utime.h>
+// CHECK_ENABLED: utime_checked.h
+// CHECK_ENABLED: #pragma CHECKED_SCOPE on
+// CHECK_DISABLED-NOT: utime_checked.h
+// CHECK_DISABLED-NOT: #pragma CHECKED_SCOPE on

--- a/tests/checked_headers/redeclare_libs_mixed.c
+++ b/tests/checked_headers/redeclare_libs_mixed.c
@@ -68,10 +68,3 @@
 #include <checkedc_extensions.h>
 // CHECK_MIXED: checkedc_extensions.h
 // CHECK_MIXED: #pragma CHECKED_SCOPE on
-
-
-// Posix Headers
-// These header files may or may not be present in all environments.
-#include <unistd_checked.h>
-#include <sys/socket.h>
-#include <arpa/inet_checked.h>

--- a/tests/checked_headers/redeclare_libs_mixed.c
+++ b/tests/checked_headers/redeclare_libs_mixed.c
@@ -65,6 +65,16 @@
 // CHECK_MIXED: time_checked.h
 // CHECK_MIXED: #pragma CHECKED_SCOPE on
 
+// Headers that are not in the C standard but are still present on Windows
+
+#include <fcntl.h>
+// CHECK_MIXED-NOT: fcntl_checked.h
+// CHECK_MIXED-NOT: #pragma CHECKED_SCOPE on
+
+#include <sys/stat_checked.h>
+// CHECK_MIXED: stat_checked.h
+// CHECK_MIXED: #pragma CHECKED_SCOPE on
+
 #include <checkedc_extensions.h>
 // CHECK_MIXED: checkedc_extensions.h
 // CHECK_MIXED: #pragma CHECKED_SCOPE on

--- a/tests/checked_headers/redeclare_libs_mixed_linux.c
+++ b/tests/checked_headers/redeclare_libs_mixed_linux.c
@@ -31,3 +31,27 @@
 #include <arpa/inet_checked.h>
 // CHECK_MIXED: inet_checked.h
 // CHECK_MIXED: #pragma CHECKED_SCOPE on
+
+#include <grp.h>
+// CHECK_MIXED-NOT: grp_checked.h
+// CHECK_MIXED-NOT: #pragma CHECKED_SCOPE on
+
+#include <netdb_checked.h>
+// CHECK_MIXED: netdb_checked.h
+// CHECK_MIXED: #pragma CHECKED_SCOPE on
+
+#include <poll.h>
+// CHECK_MIXED-NOT: poll_checked.h
+// CHECK_MIXED-NOT: #pragma CHECKED_SCOPE on
+
+#include <pwd_checked.h>
+// CHECK_MIXED: pwd_checked.h
+// CHECK_MIXED: #pragma CHECKED_SCOPE on
+
+#include <syslog.h>
+// CHECK_MIXED-NOT: syslog_checked.h
+// CHECK_MIXED-NOT: #pragma CHECKED_SCOPE on
+
+#include <utime_checked.h>
+// CHECK_MIXED: utime_checked.h
+// CHECK_MIXED: #pragma CHECKED_SCOPE on


### PR DESCRIPTION
As previously discussed with Sulekha, CCI is preparing to submit a batch of changes to the checked headers that we made in support of our recent porting efforts.  I'm going ahead and submitting a draft PR so that I can more easily refer to some of our changes in issues that I'm about to file.  Warning: I may still overwrite the commits of the PR via force-push.

One part of the PR that I believe is in final form and that you can go ahead and review if you wish is the change to make `#include`-ing a wrapper header an error if the original header does not exist on the system.  This change is currently in [this commit](https://github.com/microsoft/checkedc/commit/a908b533ac427dff53962840c11367411261abab) (though I may overwrite the commit later).  It might make sense to make this change into a separate PR (at the cost of some additional overhead) because it is different in nature from all our other changes; let me know if you'd like me to do so.

The corresponding draft PR for the tests in the checkedc-clang repository is microsoft/checkedc-clang#1064.